### PR TITLE
Treat dots/underscores as equivalent in Local API Server model lookup

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -485,6 +485,19 @@ pub fn get_destination_path(original_path: &str, prefix: &str) -> String {
     remove_prefix(original_path, prefix)
 }
 
+/// Compare a model id from an incoming request against a model id from an
+/// active session. Dots and underscores are treated as equivalent so that
+/// e.g. `Qwen3_5-9B-MLX-4bit` matches `Qwen3.5-9B-MLX-4bit` — some clients
+/// (and filesystems) substitute one for the other.
+pub fn model_ids_match(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.bytes().zip(b.bytes()).all(|(x, y)| {
+        x == y || matches!((x, y), (b'.', b'_') | (b'_', b'.'))
+    })
+}
+
 pub fn allowed_methods_for_path(path: &str) -> Option<&'static [&'static str]> {
     match path {
         "/" | "/openapi.json" | "/docs/swagger-ui.css" | "/docs/swagger-ui-bundle.js" => {
@@ -809,7 +822,7 @@ async fn is_embedding_session(
             let guard = sessions.lock().await;
             guard
                 .values()
-                .find(|s| s.info.model_id == model_id)
+                .find(|s| model_ids_match(&s.info.model_id, model_id))
                 .map(|s| s.info.is_embedding)
                 .unwrap_or(false)
         }
@@ -817,7 +830,7 @@ async fn is_embedding_session(
             let guard = mlx_sessions.lock().await;
             guard
                 .values()
-                .find(|s| s.info.model_id == model_id)
+                .find(|s| model_ids_match(&s.info.model_id, model_id))
                 .map(|s| s.info.is_embedding)
                 .unwrap_or(false)
         }
@@ -840,14 +853,14 @@ async fn resolve_local_session(
             let guard = sessions.lock().await;
             guard
                 .values()
-                .find(|s| s.info.model_id == model_id)
+                .find(|s| model_ids_match(&s.info.model_id, model_id))
                 .map(|s| (s.info.port, s.info.api_key.clone()))
         }
         "mlx" => {
             let guard = mlx_sessions.lock().await;
             guard
                 .values()
-                .find(|s| s.info.model_id == model_id)
+                .find(|s| model_ids_match(&s.info.model_id, model_id))
                 .map(|s| (s.info.port, s.info.api_key.clone()))
         }
         _ => None,
@@ -1437,13 +1450,13 @@ async fn inner_proxy_request<R: Runtime>(
                             let sessions_guard = sessions.lock().await;
                             let llama_session = sessions_guard
                                 .values()
-                                .find(|s| s.info.model_id == model_id);
+                                .find(|s| model_ids_match(&s.info.model_id, model_id));
 
                             let mlx_session_info = {
                                 let mlx_guard = mlx_sessions.lock().await;
                                 mlx_guard
                                     .values()
-                                    .find(|s| s.info.model_id == model_id)
+                                    .find(|s| model_ids_match(&s.info.model_id, model_id))
                                     .map(|s| s.info.clone())
                             };
 
@@ -1611,7 +1624,7 @@ async fn inner_proxy_request<R: Runtime>(
                             // Check both llama.cpp and MLX sessions
                             let llama_session = sessions_guard
                                 .values()
-                                .find(|s| s.info.model_id == sessions_find_model);
+                                .find(|s| model_ids_match(&s.info.model_id, sessions_find_model));
 
                             let (mlx_session_info, mlx_count) = {
                                 let mut mlx_session_info: Option<SessionInfo> = None;
@@ -1620,7 +1633,7 @@ async fn inner_proxy_request<R: Runtime>(
                                 mlx_count = mlx_guard.len();
                                 if let Some(session) = mlx_guard
                                     .values()
-                                    .find(|s| s.info.model_id == sessions_find_model)
+                                    .find(|s| model_ids_match(&s.info.model_id, sessions_find_model))
                                 {
                                     // Clone just the SessionInfo since MlxBackendSession is not Clone
                                     mlx_session_info = Some(session.info.clone());
@@ -1859,7 +1872,7 @@ async fn inner_proxy_request<R: Runtime>(
                 let sessions_guard = sessions.lock().await;
                 sessions_guard
                     .values()
-                    .find(|s| s.info.model_id == metrics_model_id)
+                    .find(|s| model_ids_match(&s.info.model_id, &metrics_model_id))
                     .map(|s| (s.info.port, s.info.api_key.clone()))
             };
 

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -124,6 +124,37 @@ mod tests {
     }
 
     #[test]
+    fn test_model_ids_match_exact() {
+        assert!(proxy::model_ids_match("Qwen3.5-9B-MLX-4bit", "Qwen3.5-9B-MLX-4bit"));
+        assert!(proxy::model_ids_match("", ""));
+    }
+
+    #[test]
+    fn test_model_ids_match_dot_underscore_equivalent() {
+        // The motivating case: a client sending the underscore form must still
+        // resolve to the active session whose id uses dots.
+        assert!(proxy::model_ids_match(
+            "Qwen3_5-9B-MLX-4bit",
+            "Qwen3.5-9B-MLX-4bit",
+        ));
+        assert!(proxy::model_ids_match(
+            "Qwen3.5-9B-MLX-4bit",
+            "Qwen3_5-9B-MLX-4bit",
+        ));
+        assert!(proxy::model_ids_match("a.b_c", "a_b.c"));
+    }
+
+    #[test]
+    fn test_model_ids_match_negatives() {
+        assert!(!proxy::model_ids_match("Qwen3.5-9B", "Qwen3.5-7B"));
+        assert!(!proxy::model_ids_match("Qwen3.5", "Qwen3.5-9B"));
+        assert!(!proxy::model_ids_match("llama-3", "llama-4"));
+        // Non-{dot,underscore} chars must still match exactly.
+        assert!(!proxy::model_ids_match("a-b", "a.b"));
+        assert!(!proxy::model_ids_match("a.b", "a-b"));
+    }
+
+    #[test]
     fn test_allowed_headers() {
         let allowed_headers = [
             "accept",


### PR DESCRIPTION
## Summary
- Adds `model_ids_match(a, b)` in `src-tauri/src/core/server/proxy.rs` that compares model ids byte-by-byte, treating `.` and `_` as equivalent.
- Switches all 9 active-session lookup sites in the proxy (embedding check, post-reload session resolve, `/messages`, `/chat/completions` / `/completions` / `/embeddings` / `/messages/count_tokens`, and `/metrics`) to use the new comparator instead of `==`.
- Adds unit tests covering the motivating `Qwen3_5-9B-MLX-4bit` ↔ `Qwen3.5-9B-MLX-4bit` case plus negative cases (length mismatch, unrelated punctuation).

## Why
Some clients (and filesystems that disallow `.`) substitute `_` for `.` in model ids. Without normalization the proxy 404s with `No running session found for model '<id>'` even when a session with the equivalent dotted id is loaded.

## Test plan
- [ ] `cargo test -p app --lib core::server::tests` passes (new tests + existing ones).
- [ ] Manual: load `Qwen3.5-9B-MLX-4bit`, hit the Local API Server with `"model": "Qwen3_5-9B-MLX-4bit"`, request is routed to the running session instead of returning 404.
- [ ] Manual: confirm a genuinely unknown model id still returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)