### PR TITLE
fix(local-api-server): default Server Host to 127.0.0.1

### DIFF
--- a/web-app/src/hooks/useLocalApiServer.ts
+++ b/web-app/src/hooks/useLocalApiServer.ts
@@ -51,7 +51,7 @@ export const useLocalApiServer = create<LocalApiServerState>()(
         set({ defaultModelLocalApiServer: model }),
       lastServerModels: [],
       setLastServerModels: (models) => set({ lastServerModels: models }),
-      serverHost: '0.0.0.0',
+      serverHost: '127.0.0.1',
       setServerHost: (value) => set({ serverHost: value }),
       // Use port 0 (auto-assign) for mobile to avoid conflicts, 1337 for desktop
       serverPort: (typeof window !== 'undefined' && (window as { IS_ANDROID?: boolean }).IS_ANDROID) || (typeof window !== 'undefined' && (window as { IS_IOS?: boolean }).IS_IOS) ? 0 : 1337,


### PR DESCRIPTION
## Summary

Defaults the Local API Server bind host to `127.0.0.1` (loopback) instead of `0.0.0.0` (all interfaces). Aligns with the desktop-local-LLM default (Ollama, LM Studio) and avoids accidental LAN exposure on the empty-API-key path.

## Change

```diff
-  serverHost: '0.0.0.0',
+  serverHost: '127.0.0.1',
```

`web-app/src/hooks/useLocalApiServer.ts:55`

## Rationale

With the default empty `apiKey`, the auth gate at `src-tauri/src/core/server/proxy.rs:1333-1364` is skipped, and a `0.0.0.0` bind makes the OpenAI-compatible API reachable from any device on the same network segment. Loopback default keeps the local-use path safe and leaves LAN-reachable mode available via the existing Server Host dropdown when users opt into it.

## Migration

Existing users with `0.0.0.0` stored in Zustand persist are unaffected; their setting carries through. The change only affects fresh installs and users who never touched the setting.

Consumers that need cross-process reach (Docker on host, remote tools) set Server Host to `0.0.0.0` and configure an API key. Matches Ollama's documented pattern (`OLLAMA_HOST=0.0.0.0:11434`).

## Test plan

- [x] Fresh install starts server on `127.0.0.1`
- [x] Existing `0.0.0.0` setting persists across upgrade
- [x] Switching back to `0.0.0.0` via dropdown still works
- [x] Existing test suite at `src-tauri/src/core/server/tests.rs` passes