### PR TITLE
fix(llamacpp-upstream): bump Windows CUDA-13 backend 13.1 → 13.3 (fixes "Failed to download GPU backend")

### DIFF
--- a/extensions/llamacpp-upstream-extension/src/backend.ts
+++ b/extensions/llamacpp-upstream-extension/src/backend.ts
@@ -107,7 +107,7 @@ function buildHttpProxyOptions(): {
  * only get the bundled (re-codesigned) build that ships with each Atomic
  * Chat release.
  *
- * Windows: returns the ggml-org Windows assets (CPU / CUDA 12.4 / CUDA 13.1
+ * Windows: returns the ggml-org Windows assets (CPU / CUDA 12.4 / CUDA 13.3
  * / Vulkan) so the runtime update flow can fetch fresh builds without
  * shipping a new installer.
  *
@@ -185,7 +185,7 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
       const allowedBackends = new Set<string>([
         'win-cpu-x64',
         'win-cuda-12.4-x64',
-        'win-cuda-13.1-x64',
+        'win-cuda-13.3-x64',
         'win-vulkan-x64',
       ])
 
@@ -271,27 +271,27 @@ export function getBackendDownloadUrl(
 }
 
 /**
- * Maps an internal backend id (e.g. `win-cuda-13.1-x64`, `linux-vulkan-x64`)
+ * Maps an internal backend id (e.g. `win-cuda-13.3-x64`, `linux-vulkan-x64`)
  * to a short human-friendly variant label used by the "Latest <variant>"
  * dropdown entries. Falls back to the raw id for anything unrecognised.
  */
 export function friendlyBackendLabel(backend: string): string {
   const id = backend.replace(/\uFEFF/g, '').trim()
   if (id.endsWith('cpu-x64')) return 'CPU'
-  if (id.includes('cuda-13')) return 'CUDA 13.1'
+  if (id.includes('cuda-13')) return 'CUDA 13.3'
   if (id.includes('cuda-12')) return 'CUDA 12.4'
   if (id.includes('vulkan')) return 'Vulkan'
   return id
 }
 
 /**
- * Maps a Windows CUDA backend variant id (e.g. `win-cuda-13.1-x64`) to
+ * Maps a Windows CUDA backend variant id (e.g. `win-cuda-13.3-x64`) to
  * the matching cudart asset on the same ggml-org/llama.cpp release.
  *
- * The main `llama-{tag}-bin-win-cuda-{12.4,13.1}-x64.zip` archives ship
+ * The main `llama-{tag}-bin-win-cuda-{12.4,13.3}-x64.zip` archives ship
  * only the llama-server executable and its direct deps; the CUDA Toolkit
  * runtime DLLs (cudart64_*.dll, cublas64_*.dll, cublasLt64_*.dll, …)
- * live in a sibling `cudart-llama-bin-win-cuda-{12.4,13.1}-x64.zip`.
+ * live in a sibling `cudart-llama-bin-win-cuda-{12.4,13.3}-x64.zip`.
  * Without those DLLs, `llama-server.exe --list-devices` returns an empty
  * device list on machines that don't have the CUDA Toolkit installed
  * system-wide (GitHub issue AtomicBot-ai/Atomic-Chat#14).
@@ -300,30 +300,30 @@ export function friendlyBackendLabel(backend: string): string {
  * shipped is CUDA 12.4. Hosts whose driver only supports CUDA 11 fall
  * back to the CPU build via runtime driver-version gating.
  */
-const WINDOWS_CUDART_FILENAME: Record<'cuda-12.4' | 'cuda-13.1', string> = {
+const WINDOWS_CUDART_FILENAME: Record<'cuda-12.4' | 'cuda-13.3', string> = {
   'cuda-12.4': 'cudart-llama-bin-win-cuda-12.4-x64.zip',
-  'cuda-13.1': 'cudart-llama-bin-win-cuda-13.1-x64.zip',
+  'cuda-13.3': 'cudart-llama-bin-win-cuda-13.3-x64.zip',
 }
 
 /**
  * Same mapping in CUDA-toolkit version form, for callers that need to
  * talk to `plugin:llamacpp-upstream|is_cuda_installed` (which keys on
- * the cudart version string, e.g. `12.4` / `13.1`) rather than the
+ * the cudart version string, e.g. `12.4` / `13.3`) rather than the
  * backend variant id.
  */
-const WINDOWS_CUDA_TOOLKIT_VERSION: Record<'cuda-12.4' | 'cuda-13.1', string> = {
+const WINDOWS_CUDA_TOOLKIT_VERSION: Record<'cuda-12.4' | 'cuda-13.3', string> = {
   'cuda-12.4': '12.4',
-  'cuda-13.1': '13.1',
+  'cuda-13.3': '13.3',
 }
 
-const WINDOWS_CUDA_BACKEND_RE = /^win-(cuda-(?:12\.4|13\.1))-/
+const WINDOWS_CUDA_BACKEND_RE = /^win-(cuda-(?:12\.4|13\.3))-/
 
 function matchWindowsCudaBackend(
   backend: string
-): 'cuda-12.4' | 'cuda-13.1' | null {
+): 'cuda-12.4' | 'cuda-13.3' | null {
   const match = WINDOWS_CUDA_BACKEND_RE.exec(backend.replace(/\uFEFF/g, '').trim())
   if (!match) return null
-  return match[1] as 'cuda-12.4' | 'cuda-13.1'
+  return match[1] as 'cuda-12.4' | 'cuda-13.3'
 }
 
 /**
@@ -353,7 +353,7 @@ export function getCudartArchiveName(backend: string): string | null {
 }
 
 /**
- * Returns the CUDA Toolkit version string (e.g. `13.1`) that the Rust
+ * Returns the CUDA Toolkit version string (e.g. `13.3`) that the Rust
  * `is_cuda_installed` command expects for a given Windows CUDA backend.
  * `null` for non-CUDA backends.
  */

--- a/extensions/llamacpp-upstream-extension/src/index.ts
+++ b/extensions/llamacpp-upstream-extension/src/index.ts
@@ -144,7 +144,8 @@ function stripBom(s: string): string {
 
 function backendCategoryToLabel(category: string): string {
   switch (category) {
-    case 'cuda-cu13.1': return 'CUDA 13'
+    case 'cuda-cu13.3': return 'CUDA 13'
+    case 'cuda-cu13.1': return 'CUDA 13' // legacy on-disk installs
     case 'cuda-cu13.0': return 'CUDA 13'
     case 'cuda-cu12.4': return 'CUDA 12'
     case 'cuda-cu12.0': return 'CUDA 12'
@@ -155,9 +156,12 @@ function backendCategoryToLabel(category: string): string {
 }
 
 function get_backend_category(backend: string): string {
-  // ggml-org native Windows names (matched first so `cu13.1` / `cu12.4`
-  // don't fall through to the legacy janhq categories).
-  if (backend.includes('cuda-13.1')) return 'cuda-cu13.1'
+  // ggml-org native Windows names (matched first so `cu13.3` / `cu12.4`
+  // don't fall through to the legacy janhq categories). `cuda-13.1` is the
+  // pre-b9495 ggml-org minor — still recognized so already-installed
+  // `win-cuda-13.1-x64` folders keep their category after the 13.3 bump.
+  if (backend.includes('cuda-13.3') || backend.includes('cuda-13.1'))
+    return 'cuda-cu13.3'
   if (backend.includes('cuda-12.4')) return 'cuda-cu12.4'
   // Legacy janhq mirror names.
   if (backend.includes('cuda-13-common_cpus')) return 'cuda-cu13.0'
@@ -704,7 +708,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
         ? [
             'win-cpu-x64',
             'win-cuda-12.4-x64',
-            'win-cuda-13.1-x64',
+            'win-cuda-13.3-x64',
             'win-vulkan-x64',
           ]
         : IS_LINUX
@@ -1174,10 +1178,10 @@ export default class llamacpp_upstream_extension extends AIEngine {
   /**
    * Uses hardware detection (CUDA/Vulkan driver info) to determine the ideal
    * backend type for this machine. Returns the backend name string
-   * (e.g. "win-cuda-13.1-x64") or null if CPU is already optimal.
+   * (e.g. "win-cuda-13.3-x64") or null if CPU is already optimal.
    *
    * Naming differs by platform — Windows uses ggml-org native ids
-   * (`win-cuda-{12.4,13.1}-x64`, `win-vulkan-x64`); Linux still uses the
+   * (`win-cuda-{12.4,13.3}-x64`, `win-vulkan-x64`); Linux still uses the
    * janhq-mirror names (`linux-cuda-{12,13}-common_cpus-x64`) because the
    * upstream extension is currently only wired on macOS and Windows.
    */
@@ -1204,7 +1208,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
         arch.includes('aarch64') || arch.includes('arm64') ? 'arm64' : 'x64'
 
       if (sysInfo.os_type === 'windows') {
-        // ggml-org publishes Windows CUDA builds for 13.1 and 12.4 only —
+        // ggml-org publishes Windows CUDA builds for 13.3 and 12.4 only —
         // CUDA 11 has been dropped upstream. Hosts with driver too old
         // for CUDA 12.4 (~551.61) fall through to Vulkan/CPU below via
         // the feature-flag gating in `get_supported_features`.
@@ -1221,7 +1225,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
         // `--list-devices` alone as a degrade trigger would push those
         // users off a working CUDA-13.1 onto CUDA-12.4 / Vulkan / CPU.
         const tiers: string[] = []
-        if (features.cuda13) tiers.push(`win-cuda-13.1-${archSuffix}`)
+        if (features.cuda13) tiers.push(`win-cuda-13.3-${archSuffix}`)
         if (features.cuda12) tiers.push(`win-cuda-12.4-${archSuffix}`)
         if (features.vulkan && hasEnoughVram)
           tiers.push(`win-vulkan-${archSuffix}`)
@@ -1897,7 +1901,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
 
   /**
    * Resolves a "Latest <variant>" sentinel backend id (e.g.
-   * `win-cuda-13.1-x64`) to a concrete `<tag>/<backend>` string by looking
+   * `win-cuda-13.3-x64`) to a concrete `<tag>/<backend>` string by looking
    * up the newest release tag from the ggml-org/llama.cpp release stream.
    * Returns `null` when the release stream is unreachable or the variant is
    * not present in the latest release assets.
@@ -3207,7 +3211,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
    * it in `download-${taskId}` and feeds it to Tauri's `listen()`) does
    * not get rejected by Tauri's event-name validator. Tauri restricts
    * event names to `[A-Za-z0-9_/:-]`. ggml-org Windows backends contain
-   * `.` (`win-cuda-12.4-x64`, `win-cuda-13.1-x64`), so we must strip dots
+   * `.` (`win-cuda-12.4-x64`, `win-cuda-13.3-x64`), so we must strip dots
    * out of the backend / version portion before constructing a taskId.
    *
    * The taskId is opaque to downstream consumers — nothing parses it
@@ -3321,7 +3325,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
     // `cancelDownload(taskId)` instead of the model-abort path.
     //
     // Sanitize `version`/`backend` separately because both can now
-    // carry dots after the ggml-org switch (e.g. `win-cuda-13.1-x64`),
+    // carry dots after the ggml-org switch (e.g. `win-cuda-13.3-x64`),
     // and Tauri's `listen()` — invoked under the hood by
     // `download-extension` with `download-${taskId}` — rejects dots.
     //
@@ -3523,7 +3527,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
    * `<targetDir>/build/bin/`.
    *
    * No-op (returns immediately) when:
-   *   - `backend` is not a Windows CUDA backend (`win-cuda-{12.4,13.1}-x64`)
+   *   - `backend` is not a Windows CUDA backend (`win-cuda-{12.4,13.3}-x64`)
    *   - cudart DLLs are already present (checked via the Rust
    *     `plugin:llamacpp-upstream|is_cuda_installed` command, which also
    *     handles a legacy `<jan>/llamacpp/lib/` -> `build/bin/` migration).
@@ -3585,7 +3589,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
     )
 
     // Same Tauri event-name sanitization as the backend download path —
-    // ggml-org CUDA backends carry dots (e.g. `win-cuda-13.1-x64`) which
+    // ggml-org CUDA backends carry dots (e.g. `win-cuda-13.3-x64`) which
     // `listen('download-${taskId}', …)` in `download-extension` rejects
     // with "Event name must include only alphanumeric characters, …".
     const taskId = `llamacpp-cudart-${this.sanitizeForTauriEvent(

--- a/src-tauri/plugins/tauri-plugin-llamacpp-upstream/src/backend.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp-upstream/src/backend.rs
@@ -9,7 +9,7 @@ pub fn map_old_backend_to_new(old_backend: String) -> String {
     // Upstream provider serves two platforms with different naming streams:
     //   - macOS keeps the existing `macos-{arm64,x64}` ggml-org tarball names.
     //   - Windows uses ggml-org native zip names: `win-cpu-x64`,
-    //     `win-cuda-12.4-x64`, `win-cuda-13.1-x64`, `win-vulkan-x64`.
+    //     `win-cuda-12.4-x64`, `win-cuda-13.3-x64`, `win-vulkan-x64`.
     //
     // This function exists mainly for legacy janhq-mirror entries that may
     // have been persisted in user settings before the Windows switch to
@@ -39,7 +39,7 @@ pub fn map_old_backend_to_new(old_backend: String) -> String {
     if is_windows
         && (old_backend == "win-cpu-x64"
             || old_backend.contains("cuda-12.4")
-            || old_backend.contains("cuda-13.1")
+            || old_backend.contains("cuda-13.3")
             || old_backend == "win-vulkan-x64")
     {
         return old_backend;
@@ -51,7 +51,7 @@ pub fn map_old_backend_to_new(old_backend: String) -> String {
     //   - `win-noavx-cuda-cu{11.7,12.0,13.0}-x64` (contains `cu{11,12,13}`)
     // Match both, mapping each to its closest ggml-org tier.
     if is_windows && (old_backend.contains("cuda-13") || old_backend.contains("cu13")) {
-        return format!("win-cuda-13.1-{}", arch);
+        return format!("win-cuda-13.3-{}", arch);
     }
     if is_windows && (old_backend.contains("cuda-12") || old_backend.contains("cu12")) {
         return format!("win-cuda-12.4-{}", arch);
@@ -261,7 +261,7 @@ pub fn determine_supported_backends(
                 supported_backends.push("win-cuda-12.4-x64".to_string());
             }
             if features.cuda13 {
-                supported_backends.push("win-cuda-13.1-x64".to_string());
+                supported_backends.push("win-cuda-13.3-x64".to_string());
             }
             if features.vulkan {
                 supported_backends.push("win-vulkan-x64".to_string());
@@ -512,7 +512,7 @@ pub async fn is_cuda_installed(
     jan_data_folder_path: String,
 ) -> Result<bool, String> {
     // Define library name lookup table. ggml-org publishes Windows cudart
-    // archives for CUDA 12.4 and 13.1 only; legacy CUDA 11 entries are
+    // archives for CUDA 12.4 and 13.3 only; legacy CUDA 11 entries are
     // retained for callers that may still pass an old toolkit version.
     let mut libname_lookup: HashMap<String, &str> = HashMap::new();
     libname_lookup.insert("windows-11.7".to_string(), "cudart64_110.dll");
@@ -520,6 +520,7 @@ pub async fn is_cuda_installed(
     libname_lookup.insert("windows-12.4".to_string(), "cudart64_12.dll");
     libname_lookup.insert("windows-13.0".to_string(), "cudart64_13.dll");
     libname_lookup.insert("windows-13.1".to_string(), "cudart64_13.dll");
+    libname_lookup.insert("windows-13.3".to_string(), "cudart64_13.dll");
     libname_lookup.insert("linux-11.7".to_string(), "libcudart.so.11.0");
     libname_lookup.insert("linux-12.0".to_string(), "libcudart.so.12");
     libname_lookup.insert("linux-13.0".to_string(), "libcudart.so.13");
@@ -628,14 +629,14 @@ pub async fn prioritize_backends(
     }
 
     // Priority list based on GPU memory. The upstream provider sees
-    // ggml-org native backend names on Windows (`cuda-cu13.1`,
+    // ggml-org native backend names on Windows (`cuda-cu13.3`,
     // `cuda-cu12.4`, `vulkan`, `cpu`) and janhq/macos-style names on the
     // older code paths (`cuda-cu12.0`, `common_cpus`). Both forms are
     // listed so `get_backend_category` matches work regardless of which
     // generation of backend ids ended up in the version_backends slice.
     let backend_priorities: Vec<&str> = if has_enough_gpu_memory {
         vec![
-            "cuda-cu13.1",
+            "cuda-cu13.3",
             "cuda-cu13.0",
             "cuda-cu12.4",
             "cuda-cu12.0",
@@ -652,7 +653,7 @@ pub async fn prioritize_backends(
         ]
     } else {
         vec![
-            "cuda-cu13.1",
+            "cuda-cu13.3",
             "cuda-cu13.0",
             "cuda-cu12.4",
             "cuda-cu12.0",
@@ -712,9 +713,12 @@ pub async fn prioritize_backends(
 
 fn get_backend_category(backend_string: &str) -> Option<String> {
     // ggml-org native Windows names (matched before legacy janhq patterns
-    // to avoid `cu13.1`/`cu12.4` falling through to the older categories):
-    if backend_string.contains("cuda-13.1") {
-        return Some("cuda-cu13.1".to_string());
+    // to avoid `cu13.3`/`cu12.4` falling through to the older categories).
+    // `cuda-13.1` is the pre-b9495 ggml-org minor — still recognized so
+    // already-installed `win-cuda-13.1-x64` folders keep their category
+    // after the 13.3 bump.
+    if backend_string.contains("cuda-13.3") || backend_string.contains("cuda-13.1") {
+        return Some("cuda-cu13.3".to_string());
     }
     if backend_string.contains("cuda-12.4") {
         return Some("cuda-cu12.4".to_string());
@@ -1219,10 +1223,10 @@ mod tests {
             map_old_backend_to_new("win-cuda-12-common_cpus-x64".to_string()),
             "win-cuda-12.4-x64"
         );
-        // Legacy janhq CUDA 13 → ggml-org CUDA 13.1.
+        // Legacy janhq CUDA 13 → ggml-org CUDA 13.3.
         assert_eq!(
             map_old_backend_to_new("win-cuda-13-common_cpus-x64".to_string()),
-            "win-cuda-13.1-x64"
+            "win-cuda-13.3-x64"
         );
         // Already-new ggml-org names round-trip unchanged.
         assert_eq!(
@@ -1230,8 +1234,14 @@ mod tests {
             "win-cuda-12.4-x64"
         );
         assert_eq!(
+            map_old_backend_to_new("win-cuda-13.3-x64".to_string()),
+            "win-cuda-13.3-x64"
+        );
+        // Pre-b9495 ggml-org minor migrates forward to the current 13.3 tier
+        // (ggml-org renamed the Windows CUDA-13 asset 13.1 → 13.3).
+        assert_eq!(
             map_old_backend_to_new("win-cuda-13.1-x64".to_string()),
-            "win-cuda-13.1-x64"
+            "win-cuda-13.3-x64"
         );
     }
 
@@ -1472,7 +1482,7 @@ mod tests {
         assert!(result.contains(&"win-cpu-x64".to_string()));
         assert!(result.contains(&"win-cuda-12.4-x64".to_string()));
         assert!(result.contains(&"win-vulkan-x64".to_string()));
-        assert!(!result.contains(&"win-cuda-13.1-x64".to_string()));
+        assert!(!result.contains(&"win-cuda-13.3-x64".to_string()));
         assert!(!result.iter().any(|b| b.contains("cuda-11")));
     }
 


### PR DESCRIPTION
## Problem

Since **1.1.95**, Windows users on CUDA 13 hosts get **"Failed to download GPU backend"**. The "Better Configuration Available → CUDA 13" prompt offers a backend that 404s on download.

Root cause: **ggml-org/llama.cpp renamed the Windows CUDA-13 release asset** from `llama-{tag}-bin-win-cuda-13.1-x64.zip` to `...-cuda-13.3-x64.zip` (visible on release `b9495`). The `llamacpp-upstream` provider hardcodes the `13.1` minor as the canonical backend id, so:

- [`detectIdealBackendType()`](extensions/llamacpp-upstream-extension/src/index.ts) recommends the literal `win-cuda-13.1-x64` to every CUDA-13 host (the prompt), and
- [`getBackendDownloadUrl()`](extensions/llamacpp-upstream-extension/src/backend.ts) turns it into `…/b9495/llama-b9495-bin-win-cuda-13.1-x64.zip` → **HTTP 404**.

Observed download attempt from a reporter (1.1.95):

```
Downloading backend b9495/win-cuda-13.1-x64 from
https://github.com/ggml-org/llama.cpp/releases/download/b9495/llama-b9495-bin-win-cuda-13.1-x64.zip
Error: Failed to get file size: HTTP status 404 Not Found
```

The release only ships `llama-b9495-bin-win-cuda-13.3-x64.zip`.

## Fix (hotfix)

Bump the canonical Windows CUDA-13 minor `13.1 → 13.3` everywhere it's treated as an identity string, across the TS extension and the Rust plugin:

- recommendation tier (`detectIdealBackendType`), static variant list, remote-asset whitelist
- cudart sidecar filename + toolkit-version maps + backend regex
- category matcher + priority list + `is_cuda_installed` cudart lib lookup
- `map_old_backend_to_new` canonical target

**Back-compat:** legacy `cuda-13.1` is still recognized by the category matcher and is migrated forward to `13.3` by `map_old_backend_to_new`, so an already-installed `win-cuda-13.1-x64` folder is not orphaned. Updated the affected Rust unit tests accordingly.

## Out of scope / follow-ups

- **Driver gate unchanged.** The CUDA-13 gate (`>= 581.15`) is the documented minimum for *Toolkit 13.1*; CUDA 13.3's minimum Windows driver should be verified separately. Low risk here because the runtime device probe already degrades to 12.4 / Vulkan / CPU when a recommended tier can't enumerate a GPU.
- **Root-cause hardening** (so this never recurs on the next upstream minor bump) is tracked separately — see the companion issue: resolve the CUDA-13.x asset name dynamically from the release instead of hardcoding the minor.

## Testing

- [ ] CI (TS typecheck/vitest + `cargo test` for `tauri-plugin-llamacpp-upstream`)
- [ ] Manual: on a Windows CUDA-13 host, accept the "CUDA 13" upgrade prompt and confirm the backend downloads (no 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)