### PR TITLE
feat(web-app): sidebar status dots for thread activity

### DIFF
--- a/web-app/src/components/left-sidebar/ThreadStatusDot.tsx
+++ b/web-app/src/components/left-sidebar/ThreadStatusDot.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+type ThreadStatusDotProps = {
+  pulsing?: boolean
+}
+
+export function ThreadStatusDot({ pulsing = false }: ThreadStatusDotProps) {
+  return (
+    <span
+      className={cn(
+        'size-2 shrink-0 rounded-full bg-primary',
+        pulsing && 'animate-pulse'
+      )}
+      aria-hidden
+    />
+  )
+}

--- a/web-app/src/components/left-sidebar/ThreadStatusDot.tsx
+++ b/web-app/src/components/left-sidebar/ThreadStatusDot.tsx
@@ -8,7 +8,7 @@ export function ThreadStatusDot({ pulsing = false }: ThreadStatusDotProps) {
   return (
     <span
       className={cn(
-        'size-2 shrink-0 rounded-full bg-primary',
+        'size-1.5 shrink-0 rounded-full bg-primary',
         pulsing && 'animate-pulse'
       )}
       aria-hidden

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -30,6 +30,9 @@ import { RenameThreadDialog, DeleteThreadDialog } from '@/containers/dialogs'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { ThreadMessage } from '@janhq/core'
+import { useChatSessions, isSessionBusy } from '@/stores/chat-session-store'
+import { useThreadReadStatus } from '@/stores/thread-read-store'
+import { ThreadStatusDot } from '@/components/left-sidebar/ThreadStatusDot'
 
 //* Заголовок приветственного треда: новый бренд и старая строка из прошлых версий
 const WELCOME_THREAD_TITLES = new Set([
@@ -146,6 +149,15 @@ const ThreadItem = memo(
       }
     }
 
+    const isBusy = useChatSessions((state) =>
+      isSessionBusy(state.sessions[thread.id])
+    )
+    const isUnread = useThreadReadStatus(
+      (state) => thread.id in state.unreadThreads
+    )
+    const showStatusDot = isBusy || isUnread
+    const threadTitle = thread.title || t('common:newThread')
+
     const MenuItemWrapper = subItem ? SidebarMenuSubItem : SidebarMenuItem
     const MenuButtonWrapper = subItem ? SidebarMenuSubButton : SidebarMenuButton
 
@@ -157,7 +169,10 @@ const ThreadItem = memo(
             params={{ threadId: thread.id }}
             className="bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block"
           >
-            <span>{thread.title || t('common:newThread')}</span>
+            <span className="flex items-center gap-2 pr-8">
+              {showStatusDot && <ThreadStatusDot pulsing={isBusy} />}
+              <span className="truncate flex-1">{threadTitle}</span>
+            </span>
             {currentProjectId && lastUserMessageText && (
               <div className="text-muted-foreground text-xs mt-1 line-clamp-1 pr-10">
                 {lastUserMessageText}
@@ -167,7 +182,10 @@ const ThreadItem = memo(
         ) : (
           <MenuButtonWrapper asChild>
             <Link to="/threads/$threadId" params={{ threadId: thread.id }}>
-              <span>{thread.title || t('common:newThread')}</span>
+              <span className="flex w-full items-center gap-2">
+                {showStatusDot && <ThreadStatusDot pulsing={isBusy} />}
+                <span className="truncate flex-1">{threadTitle}</span>
+              </span>
             </Link>
           </MenuButtonWrapper>
         )}

--- a/web-app/src/hooks/useThreads.ts
+++ b/web-app/src/hooks/useThreads.ts
@@ -7,6 +7,7 @@ import { useAgentMode } from '@/hooks/useAgentMode'
 import { ExtensionManager } from '@/lib/extension'
 import { ExtensionTypeEnum, VectorDBExtension } from '@janhq/core'
 import posthog from 'posthog-js'
+import { useThreadReadStatus } from '@/stores/thread-read-store'
 
 type ThreadState = {
   threads: Record<string, Thread>
@@ -165,6 +166,7 @@ export const useThreads = create<ThreadState>()((set, get) => ({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [threadId]: _, ...remainingThreads } = state.threads
 
+      useThreadReadStatus.getState().removeThread(threadId)
       // Clean up agent mode state
       useAgentMode.getState().removeThread(threadId)
       // Clean up vector DB collection
@@ -197,6 +199,7 @@ export const useThreads = create<ThreadState>()((set, get) => ({
 
       // Delete threads and clean up their vector DB collections
       threadsToDeleteIds.forEach((threadId) => {
+        useThreadReadStatus.getState().removeThread(threadId)
         cleanupVectorDB(threadId)
         getServiceHub().threads().deleteThread(threadId)
       })
@@ -223,6 +226,7 @@ export const useThreads = create<ThreadState>()((set, get) => ({
       // Delete all threads and clean up their vector DB collections
       allThreadIds.forEach((threadId) => {
         useAgentMode.getState().removeThread(threadId)
+        useThreadReadStatus.getState().removeThread(threadId)
         cleanupVectorDB(threadId)
         getServiceHub().threads().deleteThread(threadId)
       })
@@ -248,6 +252,7 @@ export const useThreads = create<ThreadState>()((set, get) => ({
 
       // Delete threads and clean up their vector DB collections
       toDeleteSet.forEach((threadId) => {
+        useThreadReadStatus.getState().removeThread(threadId)
         cleanupVectorDB(threadId)
         getServiceHub().threads().deleteThread(threadId)
       })

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -27,6 +27,7 @@ import {
 import { generateId, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
 import type { UIMessage } from '@ai-sdk/react'
 import { useChatSessions } from '@/stores/chat-session-store'
+import { useThreadReadStatus } from '@/stores/thread-read-store'
 import {
   convertThreadMessagesToUIMessages,
   extractContentPartsFromUIMessage,
@@ -453,6 +454,7 @@ function ThreadDetail() {
 
   useEffect(() => {
     setCurrentThreadId(threadId)
+    useThreadReadStatus.getState().markRead(threadId)
     const assistant = assistants.find(
       (assistant) => assistant.id === thread?.assistants?.[0]?.id
     )

--- a/web-app/src/stores/chat-session-store.ts
+++ b/web-app/src/stores/chat-session-store.ts
@@ -5,6 +5,7 @@ import type { ChatStatus } from "ai";
 import { CustomChatTransport } from "@/lib/custom-chat-transport";
 import { notifyThreadCompleted } from "@/lib/notifications";
 import { useThreadNotifications } from "@/hooks/useThreadNotifications";
+import { useThreadReadStatus } from "@/stores/thread-read-store";
 import i18n from "@/i18n/setup";
 
 export type SessionData = {
@@ -184,6 +185,14 @@ export const useChatSessions = create<ChatSessionState>((set, get) => ({
             { title: threadTitle }
           );
           void notifyThreadCompleted(notificationTitle, notificationBody);
+        }
+
+        if (
+          hasMessages &&
+          !hasPendingTools &&
+          state.activeConversationId !== sessionId
+        ) {
+          useThreadReadStatus.getState().markUnread(sessionId);
         }
       }
 

--- a/web-app/src/stores/thread-read-store.ts
+++ b/web-app/src/stores/thread-read-store.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand'
+
+type ThreadReadState = {
+  unreadThreads: Record<string, true>
+  markUnread: (threadId: string) => void
+  markRead: (threadId: string) => void
+  removeThread: (threadId: string) => void
+  clearAll: () => void
+}
+
+export const useThreadReadStatus = create<ThreadReadState>((set) => ({
+  unreadThreads: {},
+  markUnread: (threadId) =>
+    set((state) => ({
+      unreadThreads: { ...state.unreadThreads, [threadId]: true },
+    })),
+  markRead: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.unreadThreads)) {
+        return state
+      }
+      const { [threadId]: _, ...rest } = state.unreadThreads
+      return { unreadThreads: rest }
+    }),
+  removeThread: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.unreadThreads)) {
+        return state
+      }
+      const { [threadId]: _, ...rest } = state.unreadThreads
+      return { unreadThreads: rest }
+    }),
+  clearAll: () => set({ unreadThreads: {} }),
+}))


### PR DESCRIPTION
## Summary
- Add a pulsing dot next to sidebar chat titles while a thread is generating (streaming or pending tool calls)
- Add a static dot when a background reply completes before the user opens that conversation
- Clear unread state when the thread is opened; clean up on thread deletion

## Test plan
- [x] `yarn tsc --noEmit` in `web-app` passes
- [ ] Start a reply in chat A, switch to chat B — chat A shows a pulsing dot on the left
- [ ] Wait for reply to finish while still on chat B — dot becomes static (unread)
- [ ] Open chat A — dot disappears
- [ ] Delete a thread with an unread dot — no stale state remains


Made with [Cursor](https://cursor.com)