### PR TITLE
fix(window-controls): close top gap above caption buttons when maximized (Windows)

### DIFF
--- a/web-app/src/components/WindowControls.tsx
+++ b/web-app/src/components/WindowControls.tsx
@@ -42,12 +42,15 @@ export const WindowControls = () => {
         isMaximized ? 'right-0' : 'right-4'
       )}
     >
-      <div className="flex items-center h-full">
+      <div
+        className={cn('flex h-full', isMaximized ? 'items-stretch' : 'items-center')}
+      >
         <Button
           onClick={handleMinimize}
           aria-label="Minimize"
           variant="ghost"
           size="icon-sm"
+          className={cn(isMaximized && 'h-full')}
         >
           <Minus className="size-4" />
         </Button>
@@ -56,6 +59,7 @@ export const WindowControls = () => {
           variant="ghost"
           size="icon-sm"
           aria-label="Maximize"
+          className={cn(isMaximized && 'h-full')}
         >
           <Square className="size-3" />
         </Button>
@@ -64,7 +68,9 @@ export const WindowControls = () => {
           variant="ghost"
           size="icon-sm"
           aria-label="Close"
-          className={cn(isMaximized && 'rounded-none hover:rounded-none')}
+          className={cn(
+            isMaximized && 'h-full rounded-none hover:rounded-none'
+          )}
         >
           <X className="size-4" />
         </Button>


### PR DESCRIPTION
## Problem

On Windows, when the app window is **maximized**, the custom window control buttons (minimize / maximize / close) don't reach the very top edge of the screen — there's a small dead zone above them. This defeats the Fitts's-law "corner-slam": with native Windows decorations you can throw the cursor into the top-right corner to hit **Close** without aiming, but our buttons force you to aim because of that gap.

Reported by a community member (with before/after captures comparing our buttons vs. the standard window decorator).

## Root cause

In `web-app/src/components/WindowControls.tsx`:

- The outer container is `absolute top-0 z-50 h-15` → a **60px** tall band pinned to the top edge.
- The inner row is `flex items-center h-full`, and the buttons are `size="icon-sm"` → `size-8` (**32px**).
- Centering a 32px button inside a 60px band leaves `(60 − 32) / 2 = ~14px` of empty space **above** each button.
- The existing `isMaximized` branch only switches the horizontal inset (`right-0` vs `right-4`) and squares off the Close corner — it never collapses the vertical gap.

So even though the band's top is flush with the screen in maximized mode, the buttons' clickable area starts ~14px down.

## Fix

Gate the change on `isMaximized` so **windowed mode is byte-for-byte unchanged**:

- Inner row: `items-center` → `items-stretch` when maximized.
- The three control buttons get `h-full` when maximized, so they fill the 60px band and their hit area reaches `y = 0`.
- Icons stay centered via the Button's own internal `items-center justify-center`.

```diff
-      <div className="flex items-center h-full">
+      <div
+        className={cn('flex h-full', isMaximized ? 'items-stretch' : 'items-center')}
+      >
         <Button onClick={handleMinimize} aria-label="Minimize" variant="ghost" size="icon-sm"
+          className={cn(isMaximized && 'h-full')}
         > ... </Button>
         <Button onClick={handleMaximize} variant="ghost" size="icon-sm" aria-label="Maximize"
+          className={cn(isMaximized && 'h-full')}
         > ... </Button>
         <Button onClick={handleClose} variant="ghost" size="icon-sm" aria-label="Close"
-          className={cn(isMaximized && 'rounded-none hover:rounded-none')}
+          className={cn(isMaximized && 'h-full rounded-none hover:rounded-none')}
         > ... </Button>
       </div>
```

## What is NOT affected

- **Windowed (non-maximized) mode** — all additions are gated on `isMaximized`; the wrapper class string resolves to the identical `flex items-center h-full`.
- **macOS / Linux** — `WindowControls` is mounted only under `IS_WINDOWS` in `web-app/src/routes/__root.tsx`.
- Button **width** stays `size-8` (32px); only the height fills the band when maximized.

## ⚠️ Needs Windows QA (not testable from macOS)

This was written and reviewed on macOS — please verify on a real Windows build:

- [ ] In maximized mode the Close hit area extends to the very top-right corner and a corner-slam triggers Close.
- [ ] Min/Max/Close icons stay visually centered (no shift/clip) and buttons look right at full band height.
- [ ] The separate `data-tauri-drag-region` strip (`h-12 z-20`, `__root.tsx`) does **not** steal clicks from the now-taller buttons in the top ~14px overlap. Buttons are `z-50` vs the strip's `z-20`, so they should win — but confirm the corner actually registers Close rather than starting a window drag.
- [ ] Windowed mode is visually unchanged.

## Notes

- Scope is intentionally minimal (one file, maximized-only).
- This addresses **only** the window-control-button gap. The same reporter also suggested minor tree-view polish (arrow padding + aligning the conversation `⋯` button) — tracked separately, not in this PR.