### PR TITLE
fix(sidebar): tree-view polish — center project chevron + align conversation overflow button

### DIFF
--- a/web-app/src/components/left-sidebar/NavProjects.tsx
+++ b/web-app/src/components/left-sidebar/NavProjects.tsx
@@ -67,7 +67,7 @@ function ProjectItem({
           <CollapsibleTrigger asChild>
             <SidebarMenuButton
               type="button"
-              className="w-8 shrink-0 p-0"
+              className="w-8 shrink-0 justify-center p-0"
               aria-label={isOpen ? 'Collapse project' : 'Expand project'}
             >
               <ChevronRight

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -150,7 +150,7 @@ const ThreadItem = memo(
     const MenuButtonWrapper = subItem ? SidebarMenuSubButton : SidebarMenuButton
 
     return (
-      <MenuItemWrapper>
+      <MenuItemWrapper className={cn(subItem && 'relative group/menu-item')}>
         {currentProjectId ? (
           <Link
             to="/threads/$threadId"
@@ -178,7 +178,7 @@ const ThreadItem = memo(
               className={cn(
                 'hover:bg-sidebar-foreground/8',
                 currentProjectId && 'mt-4 mr-2',
-                subItem && 'top-1'
+                subItem && '-right-5 top-1'
               )}
             >
               <MoreHorizontal />


### PR DESCRIPTION
Two small UX tweaks to the project tree-view in the left sidebar, from a community report.

## 1. Chevron padding (`NavProjects.tsx`)

**Problem:** the gap between a project's expand arrow and its folder icon reads too large, and the arrow looks off-center.

**Cause:** the chevron (`size-4`, 16px) sits in a `w-8` (32px) `SidebarMenuButton`. The button's base variant is left-aligned (`flex items-center`, no `justify-center`), so the 16px chevron hugs the left and leaves ~16px of dead space on its right before the folder icon.

**Fix:** add `justify-center` to the chevron button. The arrow is now centered in its block, which halves the gap to the folder icon (16px → ~8px) and removes the off-center look — addressing both framings the reporter suggested ("reduce the right-padding" / "center the arrow in its block"). Width stays `w-8` (hit area unchanged).

```diff
-              className="w-8 shrink-0 p-0"
+              className="w-8 shrink-0 justify-center p-0"
```

## 2. Conversation overflow button alignment (`ThreadList.tsx`)

**Problem:** a conversation's `…` button isn't aligned with the project's `…` button and can sit *above* the conversation title.

**Cause:** the conversation row's `SidebarMenuAction` is `position: absolute`, but its wrapper `SidebarMenuSubItem` is a bare `<li>` with **no `relative` and no `group/menu-item`** context (unlike the project's `SidebarMenuItem`, which has `group/menu-item relative`). So the action resolved against the wrong positioned ancestor (drifting above the title), and — because there's no `group/menu-item` ancestor — the `group-hover/menu-item:opacity-100` reveal never fired, so on desktop the conversation `…` was effectively **never shown on hover** (latent bug, not just cosmetic). Horizontally, the `SidebarMenuSub` list is inset (`mx-3.5` + `px-2.5` = 1.5rem), so the action's `right-1` landed at a different x than the project's.

**Fix:**
- Give the sub-row wrapper `relative group/menu-item` (only when `subItem`) → correct positioning context + restores the hover reveal, and keeps the button on the title row.
- Offset the action by `-right-5` so it shares the same right edge as the project `…`: project action is at `right-1` (0.25rem) of the full-width row; the sub-list inset is 1.5rem, so `0.25 − 1.5 = −1.25rem = -right-5`. Vertical `top-1` centers it on the `h-7` sub-row.

```diff
-      <MenuItemWrapper>
+      <MenuItemWrapper className={cn(subItem && 'relative group/menu-item')}>
...
-                subItem && 'top-1'
+                subItem && '-right-5 top-1'
```

## What is NOT affected

- The `currentProjectId` project-detail **card** layout is untouched — all new classes are gated on `subItem`.
- Sub-row indentation/padding of nested conversations is unchanged.
- Item 1 changes only the chevron button; the folder/name button is untouched.

## ⚠️ Needs visual QA (written + reviewed on macOS, not rendered)

These are pixel-level layout tweaks. An adversarial review pass flagged one value as computed-but-unverified — please eyeball in a running build:

- [ ] **`-right-5` horizontal offset** — confirm the conversation `…` shares the exact same right edge as the project `…`. The math (`mx-3.5 + px-2.5 = 1.5rem`, minus project `right-1`) gives `-1.25rem = -right-5`; two reviewers disagreed on this derivation, so it's the one knob to verify/tune. If it overshoots, it could poke past the sub-list right edge or near the scrollbar.
- [ ] Conversation `…` is vertically centered on its title row (not above it).
- [ ] Chevron looks centered and the gap to the folder icon feels right (if still too wide, `w-8 → w-7` is the next step; if too tight, revert to plain `justify-center`).
- [ ] Verify the conversation `…` reveals correctly on hover on desktop (this PR is expected to *fix* a case where it didn't).
- [ ] No clipping of the sub-row `…` during the project expand/collapse animation.

## Notes

- Same reporter, separate from the Windows window-control-buttons fix (#58).
- Scope is intentionally minimal (2 files).