### PR TITLE
feat(sidebar): drag-and-drop project reordering + per-row hover fixes

### DIFF
--- a/web-app/src/components/left-sidebar/NavProjects.tsx
+++ b/web-app/src/components/left-sidebar/NavProjects.tsx
@@ -3,6 +3,7 @@ import {
   FolderEditIcon,
   FolderIcon,
   FolderOpenIcon,
+  GripVertical,
   MoreHorizontal,
   Trash2,
 } from 'lucide-react'
@@ -33,6 +34,22 @@ import { useLeftPanel } from '@/hooks/useLeftPanel'
 import { useThreadManagement } from '@/hooks/useThreadManagement'
 import { useThreads } from '@/hooks/useThreads'
 import { Link, useNavigate } from '@tanstack/react-router'
+import {
+  DndContext,
+  closestCenter,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  KeyboardSensor,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { useMemo, useState } from 'react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import type { ThreadFolder } from '@/services/projects/types'
@@ -59,15 +76,39 @@ function ProjectItem({
   onDelete: (project: ThreadFolder) => void
 }) {
   const navigate = useNavigate()
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
 
   return (
-    <Collapsible open={isOpen} onOpenChange={onOpenChange} className="group/collapsible">
+    <div ref={setNodeRef} style={style} className={cn(isDragging && 'z-10')}>
+      <Collapsible open={isOpen} onOpenChange={onOpenChange} className="group/collapsible">
       <SidebarMenuItem>
-        <div className="flex w-full items-center">
+        <div className="group/project-row relative flex w-full items-center">
+          <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            aria-label="Drag to reorder project"
+            className="text-muted-foreground/50 flex h-6 w-4 shrink-0 cursor-grab touch-none items-center justify-center opacity-0 transition-opacity group-hover/project-row:opacity-100 active:cursor-grabbing"
+          >
+            <GripVertical className="size-3.5" />
+          </button>
           <CollapsibleTrigger asChild>
-            <SidebarMenuButton
+            <button
               type="button"
-              className="w-8 shrink-0 justify-center p-0"
+              className="hover:bg-sidebar-foreground/8 flex size-6 shrink-0 items-center justify-center rounded-md transition-colors"
               aria-label={isOpen ? 'Collapse project' : 'Expand project'}
             >
               <ChevronRight
@@ -76,7 +117,7 @@ function ProjectItem({
                   isOpen && 'rotate-90'
                 )}
               />
-            </SidebarMenuButton>
+            </button>
           </CollapsibleTrigger>
           <SidebarMenuButton asChild className="min-w-0 flex-1 pr-8">
             <Link to="/project/$projectId" params={{ projectId: item.id }}>
@@ -84,38 +125,38 @@ function ProjectItem({
               <span className="truncate">{item.name}</span>
             </Link>
           </SidebarMenuButton>
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuAction showOnHover className="hover:bg-sidebar-foreground/8">
-              <MoreHorizontal />
-              <span className="sr-only">More</span>
-            </SidebarMenuAction>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-48"
-            side={isMobile ? 'bottom' : 'right'}
-            align={isMobile ? 'end' : 'start'}
-          >
-            <DropdownMenuItem
-              onSelect={() => {
-                navigate({ to: '/project/$projectId', params: { projectId: item.id } })
-              }}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <SidebarMenuAction className="hover:bg-sidebar-foreground/8 transition-opacity group-hover/project-row:opacity-100 group-focus-within/project-row:opacity-100 data-[state=open]:opacity-100 md:opacity-0">
+                <MoreHorizontal />
+                <span className="sr-only">More</span>
+              </SidebarMenuAction>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              className="w-48"
+              side={isMobile ? 'bottom' : 'right'}
+              align={isMobile ? 'end' : 'start'}
             >
-              <FolderOpenIcon className="text-muted-foreground" />
-              <span>View Project</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onEdit(item)}>
-              <FolderEditIcon className="text-muted-foreground" />
-              <span>Edit Project</span>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant="destructive" onSelect={() => onDelete(item)}>
-              <Trash2 />
-              <span>Delete Project</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <DropdownMenuItem
+                onSelect={() => {
+                  navigate({ to: '/project/$projectId', params: { projectId: item.id } })
+                }}
+              >
+                <FolderOpenIcon className="text-muted-foreground" />
+                <span>View Project</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onEdit(item)}>
+                <FolderEditIcon className="text-muted-foreground" />
+                <span>Edit Project</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant="destructive" onSelect={() => onDelete(item)}>
+                <Trash2 />
+                <span>Delete Project</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
         <CollapsibleContent>
           {threads.length > 0 && (
             <SidebarMenuSub>
@@ -124,14 +165,15 @@ function ProjectItem({
           )}
         </CollapsibleContent>
       </SidebarMenuItem>
-    </Collapsible>
+      </Collapsible>
+    </div>
   )
 }
 
 export function NavProjects() {
   const { t } = useTranslation()
   const { isMobile } = useSidebar()
-  const { folders, updateFolder } = useThreadManagement()
+  const { folders, updateFolder, reorderFolders } = useThreadManagement()
   const threads = useThreads((state) => state.threads)
   const currentThreadId = useThreads((state) => state.currentThreadId)
   const projectExpanded = useLeftPanel((state) => state.projectExpanded)
@@ -183,6 +225,25 @@ export function NavProjects() {
     return false
   }
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      // Distance-based activation: drag starts as soon as the pointer moves
+      // a few px from the grip. (Delay-based activation required holding still
+      // first, so a natural grab-and-move was misread as a click.)
+      activationConstraint: {
+        distance: 4,
+      },
+    }),
+    useSensor(KeyboardSensor)
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      reorderFolders(String(active.id), String(over.id))
+    }
+  }
+
   if (folders.length === 0) {
     return null
   }
@@ -192,22 +253,36 @@ export function NavProjects() {
       <SidebarGroup className="group-data-[collapsible=icon]:hidden">
         <SidebarGroupLabel>{t('common:projects.title')}</SidebarGroupLabel>
         <SidebarMenu>
-          {folders.map((item) => {
-            const projectThreads = threadsByProject[item.id] ?? []
-            const open = isProjectOpen(item.id, projectThreads)
-            return (
-              <ProjectItem
-                key={item.id}
-                item={item}
-                isMobile={isMobile}
-                threads={projectThreads}
-                isOpen={open}
-                onOpenChange={(expanded) => setProjectExpanded(item.id, expanded)}
-                onEdit={handleEdit}
-                onDelete={handleDelete}
-              />
-            )
-          })}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            modifiers={[restrictToVerticalAxis]}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={folders.map((f) => f.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {folders.map((item) => {
+                const projectThreads = threadsByProject[item.id] ?? []
+                const open = isProjectOpen(item.id, projectThreads)
+                return (
+                  <ProjectItem
+                    key={item.id}
+                    item={item}
+                    isMobile={isMobile}
+                    threads={projectThreads}
+                    isOpen={open}
+                    onOpenChange={(expanded) =>
+                      setProjectExpanded(item.id, expanded)
+                    }
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                  />
+                )
+              })}
+            </SortableContext>
+          </DndContext>
         </SidebarMenu>
       </SidebarGroup>
 

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -150,7 +150,13 @@ const ThreadItem = memo(
     const MenuButtonWrapper = subItem ? SidebarMenuSubButton : SidebarMenuButton
 
     return (
-      <MenuItemWrapper className={cn(subItem && 'relative group/menu-item')}>
+      // SidebarMenuSubItem is a bare <li>; give it its OWN positioning + hover
+      // group (distinct from the parent project's group/menu-item) so the "..."
+      // action anchors to this row and reveals only when THIS chat is hovered —
+      // not when hovering the project or sibling chats.
+      <MenuItemWrapper
+        className={cn(subItem && 'group/menu-sub-item relative')}
+      >
         {currentProjectId ? (
           <Link
             to="/threads/$threadId"
@@ -174,11 +180,12 @@ const ThreadItem = memo(
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <SidebarMenuAction
-              showOnHover
+              showOnHover={!subItem}
               className={cn(
                 'hover:bg-sidebar-foreground/8',
                 currentProjectId && 'mt-4 mr-2',
-                subItem && '-right-5 top-1'
+                subItem &&
+                  'top-1 transition-opacity group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0'
               )}
             >
               <MoreHorizontal />

--- a/web-app/src/hooks/useThreadManagement.ts
+++ b/web-app/src/hooks/useThreadManagement.ts
@@ -9,6 +9,7 @@ type ThreadManagementState = {
   setFolders: (folders: ThreadFolder[]) => void
   addFolder: (name: string, assistantId?: string) => Promise<ThreadFolder>
   updateFolder: (id: string, name: string, assistantId?: string) => Promise<void>
+  reorderFolders: (activeId: string, overId: string) => Promise<void>
   deleteFolder: (id: string) => Promise<void>
   deleteFolderWithThreads: (id: string) => Promise<void>
   getFolderById: (id: string) => ThreadFolder | undefined
@@ -35,6 +36,23 @@ const useThreadManagementStore = create<ThreadManagementState>()((set, get) => (
     await projectsService.updateProject(id, name, assistantId)
     const updatedProjects = await projectsService.getProjects()
     set({ folders: updatedProjects })
+  },
+
+  reorderFolders: async (activeId, overId) => {
+    if (activeId === overId) return
+    const { folders } = get()
+    const oldIndex = folders.findIndex((f) => f.id === activeId)
+    const newIndex = folders.findIndex((f) => f.id === overId)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const reordered = [...folders]
+    const [moved] = reordered.splice(oldIndex, 1)
+    reordered.splice(newIndex, 0, moved)
+
+    // Optimistically update the UI, then persist the new order
+    set({ folders: reordered })
+    const projectsService = getServiceHub().projects()
+    await projectsService.setProjects(reordered)
   },
 
   deleteFolder: async (id) => {


### PR DESCRIPTION
## What & why

Follow-up to community feedback on the projects sidebar. Adds project reordering and fixes a few hover/alignment glitches in the projects + nested-chats list.

### Changes

**Drag-and-drop project reordering**
- Projects can now be reordered by dragging (built on the `@dnd-kit` already used elsewhere in the app, e.g. `AddEditMCPServer`).
- The new order is persisted via `projectsService.setProjects`, and is **automatically reused by the "Add to project" dropdown** — both read the same `folders` array, so no extra wiring is needed.
- Drag is via a **grip handle** that reveals on row hover, with **distance-based** activation, so a plain click still navigates / toggles the project (no accidental open on release).

**Expand-chevron alignment**
- The project expand arrow was clipping / sitting flush against the sidebar's left edge (reported on **Windows and macOS**). Replaced the oversized `w-8` button with a compact, centered toggle.

**Per-row hover isolation**
- Previously, hovering a project lit up the `...` action on the project **and all of its chats at once**, because the chat sub-items shared the parent project's `group/menu-item` hover scope (CSS `:hover` propagates to ancestors).
- Each chat sub-item now gets its own positioning + hover group (`group/menu-sub-item`), and the project's `...` lives inside its own row group (`group/project-row`). The `...` / grip now reveal only for the row under the cursor.

### Files
- `web-app/src/hooks/useThreadManagement.ts` — `reorderFolders(activeId, overId)` (optimistic update + persist).
- `web-app/src/components/left-sidebar/NavProjects.tsx` — `DndContext`/`SortableContext`, sortable rows, grip handle, compact chevron, per-row hover group.
- `web-app/src/containers/ThreadList.tsx` — per-chat-row hover group + scoped `...` action.

### Testing
Verified locally (`yarn dev`): reorder + persistence across reload, order mirrored in the "Add to project" dropdown, click-to-open and chevron-toggle unaffected, and `...` revealing strictly per hovered row across projects and nested chats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)