### PR TITLE
Resolve llama.cpp backends via self-hosted manifest (drop runtime api.github.com dependency)

### DIFF
--- a/.github/workflows/update-backends-manifest.yml
+++ b/.github/workflows/update-backends-manifest.yml
@@ -1,0 +1,73 @@
+name: Update backends manifest
+
+on:
+  schedule:
+    # Hourly at :37 (off-peak minute; avoids the :00 cron stampede on GitHub).
+    - cron: "37 * * * *"
+  workflow_dispatch: {}
+
+# Least privilege: write the release asset (contents scope) + open/update an
+# alert issue on failure (issues scope) so a frozen manifest is visible.
+permissions:
+  contents: write
+  issues: write
+
+# Never overlap runs; a hung run shouldn't block the next hour.
+concurrency:
+  group: update-backends-manifest
+  cancel-in-progress: false
+
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Generate backends.json
+        env:
+          # Lifts api.github.com rate limits / avoids unauth 403s during resolution.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/update-backends-manifest.mjs
+
+      # Everything below runs ONLY if the generator above exited 0 (steps stop on
+      # first failure by default). On failure we never reach the upload -> last-good
+      # release asset is preserved.
+
+      - name: Ensure 'backend-manifest' release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view backend-manifest >/dev/null 2>&1; then
+            gh release create backend-manifest \
+              --title "Backend manifest" \
+              --notes "Auto-generated llama.cpp backend download manifest. Do not delete: the desktop app reads backends.json from this fixed tag." \
+              --latest=false
+          fi
+
+      - name: Publish backends.json to fixed release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload backend-manifest backends.json --clobber
+
+      # M2 fix: the ONLY failure signal otherwise is a red Actions run nobody
+      # watches. If the generator failed (asset/CUDA-minor drift, >PER_PAGE churn,
+      # network), open or update a tracking issue so a frozen manifest is visible.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title="backends.json manifest update is failing"
+          body="The hourly manifest generator failed on run ${GITHUB_RUN_ID}. The last-good backends.json is still being served (no-overwrite-on-failure), but new llama.cpp releases are NOT flowing to users until this is fixed. Common causes: ggml-org renamed/added a CUDA minor, no complete release in the latest scanned page, or all download URLs failed verification. Run log: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/backends.json
+++ b/backends.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-17T20:37:00.000Z",
+  "tag_name": "b9690",
+  "assets": [
+    { "name": "llama-b9690-bin-win-cpu-x64.zip" },
+    { "name": "llama-b9690-bin-win-cuda-12.4-x64.zip" },
+    { "name": "llama-b9690-bin-win-cuda-13.3-x64.zip" },
+    { "name": "llama-b9690-bin-win-vulkan-x64.zip" },
+    { "name": "llama-b9690-bin-ubuntu-x64.tar.gz" },
+    { "name": "llama-b9690-bin-ubuntu-vulkan-x64.tar.gz" },
+    { "name": "cudart-llama-bin-win-cuda-12.4-x64.zip" },
+    { "name": "cudart-llama-bin-win-cuda-13.3-x64.zip" }
+  ]
+}

--- a/docs/backends-manifest.md
+++ b/docs/backends-manifest.md
@@ -1,0 +1,97 @@
+# llama.cpp backends manifest
+
+## What it is
+
+`backends.json` is a small, self-hosted **mirror of one ggml-org/llama.cpp GitHub
+release** (its tag and the list of asset filenames). The desktop app reads it to
+discover the newest llama.cpp build it can download, **instead of calling
+`api.github.com` at runtime**.
+
+Why: the unauthenticated GitHub API is rate-limited to 60 requests/hr/IP. Fresh
+installs (especially on shared/NAT'd Windows networks) hit that limit and silently
+got *zero* downloadable backends -- a no-backend dead-end (GH #56 / ATO-199). A
+single static asset has no such limit.
+
+Note: only the **index lookup** moved. The actual backend archives still download
+from the ggml-org CDN -- the app reconstructs each download URL from the asset name
+in the manifest against `github.com/ggml-org/llama.cpp/releases/download/<tag>/...`.
+
+## Shape contract (do not break)
+
+The app parser (`extensions/llamacpp-upstream-extension/src/backend.ts`) reads
+`release.tag_name` and iterates `release.assets[].name`, regex-matching the GitHub
+asset filenames. The manifest therefore **mirrors GitHub's release JSON shape**:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "<ISO-8601 UTC>",
+  "tag_name": "<ggml-org release tag, e.g. b9690>",
+  "assets": [ { "name": "llama-<tag>-bin-win-cpu-x64.zip" }, ... ]
+}
+```
+
+A keyed `{ backends, cudart }` URL map would be read by the parser as **zero
+assets** and every fetch would return `[]` -- the exact dead-end this change fixes.
+Keep the mirror shape.
+
+## Stable URL
+
+The app fetches this permanent URL (fixed release tag `backend-manifest`, fixed
+asset name `backends.json` -- only the contents change):
+
+```
+https://github.com/AtomicBot-ai/Atomic-Chat/releases/download/backend-manifest/backends.json
+```
+
+## How it's updated
+
+`.github/workflows/update-backends-manifest.yml` runs hourly (cron `37 * * * *`)
+and on manual dispatch. Each run:
+
+1. Runs `scripts/update-backends-manifest.mjs`, which:
+   - lists the latest 100 ggml-org/llama.cpp releases,
+   - picks the newest non-draft / non-prerelease whose **fully-uploaded** assets
+     include **every** required backend + cudart file,
+   - **verifies every download URL is reachable** (redirect-safe ranged GET) before
+     writing,
+   - writes `backends.json` atomically (temp file + rename).
+2. Ensures the `backend-manifest` release exists (creates it once if missing).
+3. Uploads `backends.json` to that release with `--clobber` (in-place replace).
+4. On failure, opens/updates a tracking GitHub issue so a frozen manifest is
+   visible (the only other signal is a red Actions run nobody watches).
+
+The script needs Node 20+ and **no npm dependencies**.
+
+## Invariants
+
+- **No-overwrite-on-failure.** Any error (network, missing/partial asset,
+  unreachable URL, unparseable response) makes the generator exit non-zero *before*
+  writing, and the workflow's later create/upload steps never run. The previously
+  published (last-good) `backends.json` is left untouched.
+- **Token never leaves api.github.com.** The `GITHUB_TOKEN` is sent only to the
+  releases API. Download-URL verification sends no auth, so the bearer token is
+  never forwarded across the redirect to the asset CDN.
+- **Never cache empty (app side).** The app keeps a disk cache of the last
+  *non-empty* catalog and falls back to it when the manifest is unreachable. It
+  **never** caches an empty result: callers treat an empty catalog as the canonical
+  "offline / release stream unreachable" signal, so caching `[]` would poison it.
+  Offline resolution order: live manifest -> last-good disk cache -> `[]`
+  (bundled/local only).
+- **macOS is bundled-only.** The app never fetches the manifest on macOS; the
+  resolver returns `[]` before any network call there, by design.
+
+## Known limits / follow-ups
+
+- **CUDA minors (`12.4`, `13.3`) are pinned** in the generator's required-asset
+  list. When ggml-org bumps a minor (e.g. `12.4 -> 12.6`), no scanned release will
+  match -> the generator exits non-zero -> last-good is preserved (safe) and the
+  failure-issue is filed. Resolution requires editing the script. The app-side
+  regex is already minor-agnostic; deriving the minors from the release contents is
+  a worthwhile follow-up.
+- **First-run upload failure** leaves the `backend-manifest` release with no asset
+  -> the URL 404s and apps fall back to cache/local. Not a regression for existing
+  users (the asset already exists, so `create` is skipped).
+- **No Linux CUDA build** -- ggml-org publishes none; Linux NVIDIA users use the
+  Vulkan backend. The app currently surfaces this silently; a user-facing note is a
+  possible follow-up.

--- a/extensions/llamacpp-upstream-extension/src/backend.ts
+++ b/extensions/llamacpp-upstream-extension/src/backend.ts
@@ -15,8 +15,16 @@ import {
 // Upstream provider points at the official ggml-org/llama.cpp release stream.
 // Note: this is intentionally NOT janhq/llama.cpp (legacy fork mirror) and
 // NOT AtomicBot-ai/atomic-llama-cpp-turboquant (our TurboQuant fork).
-const LLAMACPP_RELEASES_API =
-  'https://api.github.com/repos/ggml-org/llama.cpp/releases/latest'
+//
+// The release INDEX is now read from a self-hosted manifest published as a
+// GitHub release asset on a fixed tag, instead of api.github.com at runtime:
+// the unauthenticated GitHub API (60 req/hr/IP) silently rate-limited fresh
+// Windows installs into a no-backend dead-end (GH #56 / ATO-199). The manifest
+// MIRRORS GitHub's release JSON shape -- { tag_name, assets: [{ name }] } --
+// so the asset-name parsing below is unchanged. Asset DOWNLOADS still resolve
+// against the ggml-org CDN via LLAMACPP_DOWNLOAD_BASE; only the index moved.
+const LLAMACPP_BACKEND_MANIFEST_URL =
+  'https://github.com/AtomicBot-ai/Atomic-Chat/releases/download/backend-manifest/backends.json'
 const LLAMACPP_DOWNLOAD_BASE =
   'https://github.com/ggml-org/llama.cpp/releases/download'
 
@@ -127,7 +135,6 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
   // tarball is hand-picked + re-codesigned at build time; we deliberately
   // don't pull from ggml-org at runtime.
   if (osType === 'macos') {
-    void LLAMACPP_RELEASES_API
     return []
   }
 
@@ -139,7 +146,9 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
     arch.includes('aarch64') || arch.includes('arm64') ? 'arm64' : 'x64'
 
   try {
-    console.info(`[fetchRemoteBackends] Fetching ${LLAMACPP_RELEASES_API}...`)
+    console.info(
+      `[fetchRemoteBackends] Fetching ${LLAMACPP_BACKEND_MANIFEST_URL}...`
+    )
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 15_000)
     let resp: Response
@@ -147,9 +156,9 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
       // Use the Tauri HTTP client (reqwest) so we can (a) honor the
       // user-configured HTTPS proxy from Settings → Proxy and (b) apply a
       // hard `connectTimeout`. The plain WebView `fetch` ignores the app's
-      // proxy config, which made this lookup fail on GitHub-restricted
-      // networks even when the user had a working proxy set up.
-      resp = await tauriFetch(LLAMACPP_RELEASES_API, {
+      // proxy config, which made this lookup fail on restricted networks
+      // even when the user had a working proxy set up.
+      resp = await tauriFetch(LLAMACPP_BACKEND_MANIFEST_URL, {
         headers: { 'User-Agent': 'atomic-chat' },
         signal: controller.signal,
         connectTimeout: 15_000,
@@ -159,16 +168,32 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
       clearTimeout(timeout)
     }
     if (!resp.ok) {
-      const rateLimitRemaining = resp.headers.get('x-ratelimit-remaining')
+      // Distinguish the failure modes that matter operationally. 403/429 is the
+      // original ATO-199 rate-limit; 401 is auth; 5xx is host/CDN. We do not
+      // retry here (the manifest is a static asset on a fixed tag; the next
+      // hourly publish + the user's next launch are the natural retries), and
+      // we never retry-on-403. All cases degrade to last-good cache / local.
+      const status = resp.status
+      const kind =
+        status === 401
+          ? 'auth (401)'
+          : status === 403 || status === 429
+            ? 'rate-limited/forbidden (will NOT retry)'
+            : status >= 500
+              ? 'manifest host 5xx'
+              : `unexpected ${status}`
       console.warn(
-        `[fetchRemoteBackends] GitHub API returned ${resp.status} (rate-limit-remaining: ${rateLimitRemaining}), using local backends only`
+        `[fetchRemoteBackends] manifest fetch failed: ${kind}; falling back to last-good cache / local backends only`
       )
-      return []
+      return await readBackendManifestCache(osType, archSuffix)
     }
 
+    // Manifest mirrors GitHub's release JSON: { tag_name, assets:[{name}] }.
+    // `tag` (alias of tag_name) is accepted too so the publisher can emit
+    // either field name. Asset parsing below is therefore unchanged.
     const release = await resp.json()
-    const tag: string = release.tag_name
-    if (!tag) return []
+    const tag: string = release.tag_name ?? release.tag
+    if (!tag) return await readBackendManifestCache(osType, archSuffix)
 
     const assets: { name: string }[] = release.assets ?? []
     const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -208,6 +233,13 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
         `[fetchRemoteBackends] Found ${backends.length} remote backends for win-${archSuffix}:`,
         backends.map((b) => b.backend)
       )
+      // Persist last-good so a later rate-limit/offline lookup degrades to the
+      // most recent successful catalog instead of []. GUARD: never cache an
+      // empty list — an empty catalog is exactly the "offline" signal callers
+      // (index.ts recommendation gate) rely on; caching it would poison it.
+      if (backends.length > 0) {
+        await writeBackendManifestCache(osType, archSuffix, backends)
+      }
       return backends
     }
 
@@ -239,9 +271,93 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
       `[fetchRemoteBackends] Found ${backends.length} remote backends for linux-${archSuffix}:`,
       backends.map((b) => b.backend)
     )
+    if (backends.length > 0) {
+      await writeBackendManifestCache(osType, archSuffix, backends)
+    }
     return backends
   } catch (err) {
-    console.warn('[fetchRemoteBackends] Failed to fetch remote backends:', err)
+    // Network abort/timeout/dead-proxy all land here. Distinguish abort (our
+    // 15s timeout fired) from other transport errors for log clarity, then
+    // degrade to last-good cache rather than [] so a transient outage doesn't
+    // wipe the catalog.
+    const isAbort =
+      err != null && typeof err === 'object' && (err as { name?: string }).name === 'AbortError'
+    console.warn(
+      `[fetchRemoteBackends] Failed to fetch remote backends (${
+        isAbort ? 'timeout/abort' : 'transport error'
+      }):`,
+      err
+    )
+    return await readBackendManifestCache(osType, archSuffix)
+  }
+}
+
+/**
+ * Disk cache of the last *non-empty* remote backend catalog, keyed by
+ * os/arch. Lets a rate-limited / offline manifest lookup degrade to the most
+ * recent successful catalog instead of [] — without ever resurrecting an
+ * empty list (callers treat [] as the canonical "offline" signal).
+ *
+ * Stored under the same provider tree the rest of this module already owns:
+ *   <Jan data folder>/llamacpp-upstream/backend-manifest-cache-<os>-<arch>.json
+ */
+async function backendManifestCachePath(
+  osType: string,
+  archSuffix: string
+): Promise<string> {
+  const janDataFolderPath = await getJanDataFolderPath()
+  return await joinPath([
+    janDataFolderPath,
+    'llamacpp-upstream',
+    `backend-manifest-cache-${osType}-${archSuffix}.json`,
+  ])
+}
+
+async function writeBackendManifestCache(
+  osType: string,
+  archSuffix: string,
+  backends: BackendVersion[]
+): Promise<void> {
+  // GUARD: never cache empty — an empty catalog is the offline signal.
+  if (!backends || backends.length === 0) return
+  try {
+    const path = await backendManifestCachePath(osType, archSuffix)
+    await fs.writeFileSync(path, JSON.stringify(backends))
+  } catch (err) {
+    console.warn('[fetchRemoteBackends] Failed to write manifest cache:', err)
+  }
+}
+
+async function readBackendManifestCache(
+  osType: string,
+  archSuffix: string
+): Promise<BackendVersion[]> {
+  try {
+    const path = await backendManifestCachePath(osType, archSuffix)
+    if (!(await fs.existsSync(path))) return []
+    // Force a string return: this fs shim forwards args to the host IPC, and an
+    // encoding-less read can return a Buffer-like/object. Passing 'utf8' (as the
+    // app does elsewhere) guarantees a string so JSON.parse works — otherwise
+    // String(obj) yields "[object Object]" and the cache silently never loads.
+    const raw = await fs.readFileSync(path, 'utf8')
+    const text = typeof raw === 'string' ? raw : String(raw)
+    const parsed = JSON.parse(text)
+    if (!Array.isArray(parsed) || parsed.length === 0) return []
+    // Defensive: only surface well-formed entries.
+    const out: BackendVersion[] = []
+    for (const e of parsed) {
+      if (e && typeof e.version === 'string' && typeof e.backend === 'string') {
+        out.push({ version: e.version, backend: e.backend, order: 0 })
+      }
+    }
+    if (out.length > 0) {
+      console.info(
+        `[fetchRemoteBackends] Using last-good manifest cache (${out.length} backends for ${osType}-${archSuffix})`
+      )
+    }
+    return out
+  } catch (err) {
+    console.warn('[fetchRemoteBackends] Failed to read manifest cache:', err)
     return []
   }
 }

--- a/scripts/update-backends-manifest.mjs
+++ b/scripts/update-backends-manifest.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// scripts/update-backends-manifest.mjs
+//
+// Generates backends.json: a static, self-hosted MIRROR of one ggml-org/llama.cpp
+// GitHub release, so the Atomic Chat desktop app never calls api.github.com at
+// runtime (the unauthenticated API's 60 req/hr/IP limit silently dead-ended fresh
+// Windows installs -- GH #56 / ATO-199).
+//
+// SHAPE CONTRACT (critical): the app's parser (extensions/llamacpp-upstream-extension/
+// src/backend.ts) reads `release.tag_name` and iterates `release.assets[].name`,
+// regex-matching the GitHub asset filenames. Therefore this manifest MUST mirror
+// GitHub's release JSON exactly:
+//   { schemaVersion, generatedAt, tag_name, assets: [ { name } ... ] }
+// Do NOT emit a {backends,cudart} keyed-URL map -- the parser would read it as
+// zero assets and every fetch would return [] (the exact dead-end we are fixing).
+//
+// Resolves the newest ggml-org/llama.cpp release whose FULLY-UPLOADED assets include
+// every required backend + cudart file, verifies every download URL is reachable
+// (ranged GET, redirect-safe), then writes backends.json atomically.
+//
+// No-overwrite-on-failure: on ANY error (network, missing asset, unreachable URL)
+// the process exits non-zero WITHOUT touching backends.json, so the last-good
+// manifest is preserved and the workflow's publish steps never run.
+//
+// Requires Node 20+ (global fetch). No npm dependencies.
+// Auth: uses process.env.GITHUB_TOKEN if present (raises rate limits / avoids 403)
+//       for the api.github.com listing ONLY -- never for asset-CDN requests.
+
+import { writeFileSync, renameSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const SCHEMA_VERSION = 1;
+const OWNER = "ggml-org";
+const REPO = "llama.cpp";
+const PER_PAGE = 100; // M2 fix: scan deep enough to skip churn / partial releases.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_PATH = join(__dirname, "..", "backends.json");
+
+// Required backend asset filenames (functions of the release tag). Keys are only
+// labels for error messages; the app keys off the filenames themselves.
+// CUDA minors (12.4, 13.3) are what ggml-org currently ships. There is
+// intentionally NO linux-cuda entry: ggml-org publishes no ubuntu CUDA build
+// (Linux NVIDIA users use the Vulkan backend).
+const REQUIRED_BACKENDS = {
+  "win-cpu-x64": (t) => `llama-${t}-bin-win-cpu-x64.zip`,
+  "win-cuda-12.4-x64": (t) => `llama-${t}-bin-win-cuda-12.4-x64.zip`,
+  "win-cuda-13.3-x64": (t) => `llama-${t}-bin-win-cuda-13.3-x64.zip`,
+  "win-vulkan-x64": (t) => `llama-${t}-bin-win-vulkan-x64.zip`,
+  "ubuntu-x64": (t) => `llama-${t}-bin-ubuntu-x64.tar.gz`,
+  "ubuntu-vulkan-x64": (t) => `llama-${t}-bin-ubuntu-vulkan-x64.tar.gz`,
+};
+
+// CUDA runtime companion zips (Windows only; tag-independent filenames).
+const REQUIRED_CUDART = {
+  "win-cuda-12.4-x64": () => `cudart-llama-bin-win-cuda-12.4-x64.zip`,
+  "win-cuda-13.3-x64": () => `cudart-llama-bin-win-cuda-13.3-x64.zip`,
+};
+
+// api.github.com headers: token is fine here (same origin we authenticate to).
+function apiHeaders() {
+  const h = {
+    "User-Agent": "atomic-chat-backends-manifest",
+    Accept: "application/vnd.github+json",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    h.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  return h;
+}
+
+async function fetchReleases() {
+  const url = `https://api.github.com/repos/${OWNER}/${REPO}/releases?per_page=${PER_PAGE}`;
+  const res = await fetch(url, { headers: apiHeaders() });
+  if (!res.ok) {
+    throw new Error(`GitHub releases API returned ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  if (!Array.isArray(data)) {
+    throw new Error("Unexpected releases API response (not an array)");
+  }
+  return data;
+}
+
+// Required filenames for a given tag (backends + cudart), in a stable order.
+function requiredFilenames(tag) {
+  return [
+    ...Object.values(REQUIRED_BACKENDS).map((make) => make(tag)),
+    ...Object.values(REQUIRED_CUDART).map((make) => make()),
+  ];
+}
+
+// True iff this release has every required asset AND each is fully uploaded.
+// M1 fix: ignore assets still in `state: "uploading"/"starting"` so we skip an
+// in-progress release and pick the prior complete one instead of going red.
+function releaseHasAllAssets(release) {
+  const tag = release.tag_name;
+  if (!tag) return false;
+  const ready = new Set(
+    (release.assets || [])
+      .filter((a) => a.state === "uploaded")
+      .map((a) => a.name)
+  );
+  return requiredFilenames(tag).every((name) => ready.has(name));
+}
+
+function downloadUrl(tag, filename) {
+  return `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/${filename}`;
+}
+
+// Verify a download URL is reachable.
+// C1 fix: NEVER send Authorization / api Accept here. These URLs 302-redirect to
+//   objects.githubusercontent.com (signed CDN); forwarding a bearer token across
+//   that redirect leaks it, and signed URLs reject extra auth (-> false failures).
+// C2 fix: many CDN signed URLs reject HEAD (403/405) but serve GET. Use a ranged
+//   GET (1 byte) following redirects; accept 200 or 206.
+async function verifyUrl(url) {
+  const res = await fetch(url, {
+    method: "GET",
+    redirect: "follow",
+    headers: {
+      "User-Agent": "atomic-chat-backends-manifest",
+      Range: "bytes=0-0",
+    },
+  });
+  if (res.status !== 200 && res.status !== 206) {
+    throw new Error(`GET ${url} -> ${res.status} (expected 200/206)`);
+  }
+  // Drain/cancel the (tiny) body so the socket can be reused/closed promptly.
+  try {
+    await res.body?.cancel?.();
+  } catch {
+    /* ignore */
+  }
+}
+
+async function main() {
+  const releases = await fetchReleases();
+
+  // Newest-first; first non-draft, non-prerelease with every fully-uploaded asset.
+  const chosen = releases.find(
+    (r) => !r.draft && !r.prerelease && releaseHasAllAssets(r)
+  );
+  if (!chosen) {
+    throw new Error(
+      `No release among the latest ${PER_PAGE} has all required (fully-uploaded) assets`
+    );
+  }
+
+  const tag = chosen.tag_name;
+  const filenames = requiredFilenames(tag);
+
+  // Verify every download URL BEFORE writing anything. Any failure throws -> no write.
+  await Promise.all(filenames.map((name) => verifyUrl(downloadUrl(tag, name))));
+
+  // GitHub-MIRROR shape: tag_name + assets[].name. This is exactly what the app's
+  // parser consumes, so backend.ts needs no shape-specific logic.
+  const manifest = {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    tag_name: tag,
+    assets: filenames.map((name) => ({ name })),
+  };
+
+  // Atomic local write (temp + rename). The published artifact is whatever
+  // `gh release upload --clobber` reads; this just guarantees the workspace file
+  // is never left partial if the process is interrupted mid-write.
+  const json = JSON.stringify(manifest, null, 2) + "\n";
+  const tmp = `${OUT_PATH}.tmp`;
+  writeFileSync(tmp, json, "utf8");
+  renameSync(tmp, OUT_PATH);
+
+  console.log(
+    `Wrote ${OUT_PATH} for llama.cpp ${tag} (${filenames.length} assets verified)`
+  );
+}
+
+main().catch((err) => {
+  console.error(`FAILED: ${err.message}`);
+  console.error("backends.json was NOT modified (last-good preserved).");
+  process.exit(1);
+});


### PR DESCRIPTION
> DRAFT — not yet tested locally. Needs an engineer to compile (`tsc`) the extension and CI to smoke-test the workflow before merge. Refs: GH #56, ATO-199, ATO-200, ATO-201.

## Problem

Fresh installs cannot download any llama.cpp backend. At runtime the desktop app resolves the backend catalog by calling `api.github.com/.../releases/latest` directly. Unauthenticated, that API is capped at 60 requests/hr/IP. On shared / NAT'd networks (common on Windows) that budget is exhausted, the call returns 403, and the resolver silently returns an empty catalog — a no-backend dead-end with no offline fallback (GH #56 / ATO-199; ATO-174 only reworded the error).

## Solution (5 parts)

1. **Self-hosted manifest, not the live API.** The app reads a static `backends.json` published as a GitHub *release asset* on a fixed tag (`backend-manifest`). A static asset has no per-IP rate limit. Only the **index lookup** moves; backend archives still download from the ggml-org CDN.
2. **Mirror shape (critical).** The manifest mirrors GitHub's release JSON exactly — `{ tag_name, assets: [{ name }] }` — so the app's existing asset-name regex parser is unchanged. (An earlier draft emitted a `{ backends, cudart }` URL map; the unchanged parser would have read that as zero assets and returned `[]` forever. Fixed: generator + committed JSON + docs all use the mirror shape.)
3. **Hourly generator with hard safety invariants.** A zero-dependency Node 20 script picks the newest complete release, verifies every download URL, and writes atomically. No-overwrite-on-failure: any error exits non-zero *before* writing, so the last-good asset is preserved.
4. **Last-good disk cache, app side.** When the manifest is unreachable (rate-limit, 5xx, timeout, dead proxy), the resolver degrades to the most recent *non-empty* catalog on disk. It never caches `[]` — callers treat an empty catalog as the canonical "offline" signal, so caching it would poison the recommendation gate.
5. **Honest, differentiated errors + failure visibility.** The non-ok branch distinguishes 401 / 403-429 (rate-limited, never retried) / 5xx / unexpected; the catch branch distinguishes timeout-abort from transport errors. The workflow files/updates a tracking GitHub issue on failure so a frozen manifest is visible instead of only a red Actions run nobody watches.

## What changed in this PR (file-by-file)

- **add `.github/workflows/update-backends-manifest.yml`** — hourly cron (`37 * * * *`) + manual dispatch. Least-privilege `contents: write` + `issues: write`. Concurrency guard. Generates, ensures the fixed release exists, uploads with `--clobber`, and on failure opens/updates an alert issue. Upload is reached only if the generator exits 0 (default fail-fast), so a failed run never republishes.
- **add `scripts/update-backends-manifest.mjs`** — zero-dep Node 20 generator. Scans the latest 100 releases; selects the newest non-draft/non-prerelease whose **fully-uploaded** assets (`state === "uploaded"`) include all 6 backends + 2 cudart files; verifies every download URL with a redirect-safe **ranged GET** (200/206) that sends **no auth** to the CDN (prevents token leak across the `github.com → objects.githubusercontent.com` redirect and avoids signed-URL 403s); emits the GitHub-mirror shape; writes atomically (temp + rename).
- **add `backends.json`** — committed seed mirroring ggml-org `b9690` (8 assets). Regenerated hourly.
- **add `docs/backends-manifest.md`** — what it is, the shape contract (with the "don't emit a URL map" warning), stable URL, update flow, invariants, and known limits/follow-ups.
- **modify `extensions/llamacpp-upstream-extension/src/backend.ts`** — replace the `api.github.com` index constant with `LLAMACPP_BACKEND_MANIFEST_URL` (downloads still use `LLAMACPP_DOWNLOAD_BASE`); drop the dead `void LLAMACPP_RELEASES_API` in the macOS early-return; differentiate fetch-failure modes (never-retry-on-403) and fall back to cache; cache last-good after each Windows/Linux success (guarded `length > 0`); add `writeBackendManifestCache` / `readBackendManifestCache` (the read forces `'utf8'` so the host IPC returns a string). No new imports, no new deps; `fetchRemoteBackends(): Promise<BackendVersion[]>` and the `[]`-on-failure contract are preserved, so `index.ts` needs no change.

## Stable manifest URL

```
https://github.com/AtomicBot-ai/Atomic-Chat/releases/download/backend-manifest/backends.json
```

Fixed tag, fixed asset name — only the contents change.

## How to verify

1. **Generator (local):** `GITHUB_TOKEN=<token> node scripts/update-backends-manifest.mjs` → writes a `backends.json` whose `tag_name` is the newest complete ggml-org release and whose `assets[].name` are the 8 expected filenames. Re-run after temporarily breaking an asset name to confirm it exits non-zero and leaves `backends.json` untouched.
2. **Shape round-trip:** confirm the committed `backends.json` parses through the same regex `^llama-${tag}-bin-(win-.+)\.zip$` path the app uses (non-empty catalog for win + linux).
3. **App (engineer):** point `tauriFetch` at the stable URL, confirm a fresh profile populates the backend list; then block the host (simulate offline) and confirm it degrades to the last-good cache, and that a cold cache yields `[]` (not a crash).
4. **Workflow (CI/dispatch):** run `workflow_dispatch`; confirm `backend-manifest` is created once, `backends.json` is uploaded with `--clobber`, and a forced generator failure opens a tracking issue while leaving the published asset intact.

## What still needs engineer / CI

- **Compile:** run `tsc` on `extensions/llamacpp-upstream-extension` — this PR was not type-checked locally.
- **Confirm `fs.readFileSync(path, 'utf8')` host contract** returns a string in the Tauri IPC (the `'utf8'` arg is the fix for the cache-read; verify the host honors it).
- **Smoke-test the workflow** end-to-end via `workflow_dispatch` on a branch (release create/clobber + failure-issue path) before relying on the hourly cron.
- **Confirm `BackendVersion` is exactly `{ version: string; backend: string; order: number }`** (the cache read constructs it with `order: 0`).

## Out of scope

- **Own CDN.** This deliberately reuses GitHub release assets as the host (zero new infra). Migrating the manifest to a dedicated CDN (e.g. `dl.atomic.chat`) is a separate effort and not part of this PR.
- **De-pinning CUDA minors** (`12.4` / `13.3`) in the generator — flagged as a follow-up; current behavior fails safe (last-good preserved + alert issue) when ggml-org bumps a minor.
- **User-facing Linux-CUDA messaging** — ggml-org ships no Linux CUDA build; Linux NVIDIA uses Vulkan. Surfacing that to users is a follow-up.

Refs: GH #56, ATO-199, ATO-200, ATO-201.