### PR TITLE
fix(ui): highlight the selected navigation item

### DIFF
--- a/web-app/src/components/left-sidebar/NavMain.tsx
+++ b/web-app/src/components/left-sidebar/NavMain.tsx
@@ -9,7 +9,7 @@ import {
 import { Kbd, KbdGroup } from '@/components/ui/kbd'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 
-import { Link, useNavigate } from '@tanstack/react-router'
+import { Link, useNavigate, useLocation } from '@tanstack/react-router'
 import { PlatformMetaKey } from '@/containers/PlatformMetaKey'
 import React, { useRef } from 'react'
 import {
@@ -60,6 +60,16 @@ type NavMainItem = {
   isActive?: boolean
   shortcut?: React.ReactNode
   onClick?: () => void
+}
+
+// Highlight a nav entry while its page is open. Only items with a `url`
+// (Models, Integrations, Settings) are persistent destinations; action items
+// (new chat, new project, search) have no `url` and never highlight. Matches on
+// the section root so Settings stays active across its sub-pages.
+const isNavItemActive = (pathname: string, url?: string): boolean => {
+  if (!url) return false
+  const root = '/' + (url.split('/').filter(Boolean)[0] ?? '')
+  return pathname === root || pathname.startsWith(root + '/')
 }
 
 const getNavMainItems = (
@@ -168,6 +178,7 @@ function NavMainItemWithAnimatedIcon({
       <SidebarMenuButton
         asChild={!!item.url}
         isActive={item.isActive}
+        className="data-[active=true]:bg-sidebar-foreground/15"
         onMouseEnter={() => iconRef.current?.startAnimation()}
         onMouseLeave={() => iconRef.current?.stopAnimation()}
         onClick={item.onClick}
@@ -181,6 +192,7 @@ function NavMainItemWithAnimatedIcon({
 export function NavMain() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   const { addFolder } = useThreadManagement()
   const { open: searchOpen, setOpen: setSearchOpen } = useSearchDialog()
   const { open: projectDialogOpen, setOpen: setProjectDialogOpen } =
@@ -196,7 +208,9 @@ export function NavMain() {
       useAgentMode.getState().setAgentMode(TEMPORARY_CHAT_ID, true)
       navigate({ to: route.home })
     }
-  ).filter((item) => item.title !== 'common:newAgentChat')
+  )
+    .filter((item) => item.title !== 'common:newAgentChat')
+    .map((item) => ({ ...item, isActive: isNavItemActive(pathname, item.url) }))
 
   const handleCreateProject = async (name: string, assistantId?: string) => {
     const newProject = await addFolder(name, assistantId)
@@ -227,6 +241,7 @@ export function NavMain() {
               <SidebarMenuButton
                 asChild={!!item.url}
                 isActive={item.isActive}
+                className="data-[active=true]:bg-sidebar-foreground/15"
                 onClick={item.onClick}
               >
                 {item.url ? (

--- a/web-app/src/components/left-sidebar/__tests__/NavMain.test.tsx
+++ b/web-app/src/components/left-sidebar/__tests__/NavMain.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useLocation } from '@tanstack/react-router'
+import { NavMain } from '../NavMain'
+
+// A forwardRef stub for the animated icons (NavMain attaches a ref to them).
+const { IconStub } = vi.hoisted(() => {
+  const React = require('react')
+  return { IconStub: React.forwardRef(() => null) }
+})
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...props }: any) => (
+    <a href={typeof to === 'string' ? to : '#'} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => vi.fn(),
+  useLocation: vi.fn(),
+}))
+
+// Surface `isActive` as `data-active` so the test asserts the wiring.
+vi.mock('@/components/ui/sidebar', () => ({
+  SidebarMenu: ({ children }: any) => <ul>{children}</ul>,
+  SidebarMenuItem: ({ children }: any) => <li>{children}</li>,
+  SidebarMenuButton: ({ children, isActive }: any) => (
+    <div data-testid="nav-button" data-active={String(!!isActive)}>
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/kbd', () => ({
+  Kbd: ({ children }: any) => <span>{children}</span>,
+  KbdGroup: ({ children }: any) => <span>{children}</span>,
+}))
+
+vi.mock('@/i18n/react-i18next-compat', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/containers/PlatformMetaKey', () => ({ PlatformMetaKey: () => null }))
+vi.mock('@/components/animated-icon/search', () => ({ SearchIcon: IconStub }))
+vi.mock('@/components/animated-icon/folder-plus', () => ({
+  FolderPlusIcon: IconStub,
+}))
+vi.mock('@/components/animated-icon/message-circle', () => ({
+  MessageCircleIcon: IconStub,
+}))
+vi.mock('@/components/animated-icon/settings', () => ({
+  SettingsIcon: IconStub,
+}))
+vi.mock('@/components/animated-icon/blocks', () => ({ BlocksIcon: IconStub }))
+vi.mock('@/components/animated-icon/bot', () => ({ BotIcon: IconStub }))
+
+vi.mock('@/containers/dialogs/AddProjectDialog', () => ({
+  default: () => null,
+}))
+vi.mock('@/containers/dialogs/SearchDialog', () => ({
+  SearchDialog: () => null,
+}))
+
+vi.mock('@/hooks/useThreadManagement', () => ({
+  useThreadManagement: () => ({ addFolder: vi.fn() }),
+}))
+vi.mock('@/hooks/useSearchDialog', () => ({
+  useSearchDialog: () => ({ open: false, setOpen: vi.fn() }),
+}))
+vi.mock('@/hooks/useProjectDialog', () => ({
+  useProjectDialog: () => ({ open: false, setOpen: vi.fn() }),
+}))
+vi.mock('@/hooks/useAgentMode', () => ({
+  useAgentMode: {
+    getState: () => ({ removeThread: vi.fn(), setAgentMode: vi.fn() }),
+  },
+}))
+vi.mock('@/constants/chat', () => ({ TEMPORARY_CHAT_ID: 'temp' }))
+vi.mock('@/lib/shortcuts', () => ({
+  ShortcutAction: {
+    NEW_CHAT: 'NEW_CHAT',
+    NEW_AGENT_CHAT: 'NEW_AGENT_CHAT',
+    NEW_PROJECT: 'NEW_PROJECT',
+    SEARCH: 'SEARCH',
+  },
+  PlatformShortcuts: new Proxy({}, { get: () => ({ key: 'k' }) }),
+}))
+
+const buttonFor = (label: string) =>
+  screen.getByText(label).closest('[data-testid="nav-button"]')
+
+describe('NavMain active highlight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('highlights Settings across its sub-pages, not the action items', () => {
+    vi.mocked(useLocation).mockReturnValue({
+      pathname: '/settings/privacy',
+    } as never)
+
+    render(<NavMain />)
+
+    expect(buttonFor('common:settings')).toHaveAttribute('data-active', 'true')
+    expect(buttonFor('common:models')).toHaveAttribute('data-active', 'false')
+    expect(buttonFor('common:launch')).toHaveAttribute('data-active', 'false')
+    // Action items (no route) never highlight.
+    expect(buttonFor('common:newChat')).toHaveAttribute('data-active', 'false')
+  })
+
+  it('highlights Models on the hub route', () => {
+    vi.mocked(useLocation).mockReturnValue({ pathname: '/hub/' } as never)
+
+    render(<NavMain />)
+
+    expect(buttonFor('common:models')).toHaveAttribute('data-active', 'true')
+    expect(buttonFor('common:settings')).toHaveAttribute('data-active', 'false')
+  })
+
+  it('highlights Integrations on the launch route', () => {
+    vi.mocked(useLocation).mockReturnValue({ pathname: '/launch/' } as never)
+
+    render(<NavMain />)
+
+    expect(buttonFor('common:launch')).toHaveAttribute('data-active', 'true')
+    expect(buttonFor('common:models')).toHaveAttribute('data-active', 'false')
+  })
+})

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -163,9 +163,12 @@ const SettingsMenu = () => {
             }
             return (
               <div key={menu.title}>
+                {/* Selected uses a background-relative `foreground` overlay
+                    (heavier than the hover) so it stays legible on the panel,
+                    matching the sidebar's selected treatment. */}
                 <Link
                   to={menu.route}
-                  className="block px-2 gap-1.5 cursor-pointer hover:dark:bg-secondary/60 hover:bg-secondary py-1 w-full rounded-sm [&.active]:dark:bg-secondary/80 [&.active]:bg-secondary"
+                  className="block px-2 gap-1.5 cursor-pointer hover:dark:bg-secondary/60 hover:bg-secondary py-1 w-full rounded-sm [&.active]:bg-foreground/20"
                 >
                   <div className="flex items-center justify-between">
                     <span>{t(menu.title)}</span>
@@ -204,8 +207,8 @@ const SettingsMenu = () => {
                         <div key={provider.provider}>
                           <div
                             className={cn(
-                              'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm [&.active]:bg-secondary/80 text-foreground',
-                              isActive && 'bg-secondary',
+                              'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-foreground',
+                              isActive && 'bg-foreground/20',
                               // hidden for llama.cpp provider for setup remote provider
                               provider.provider === 'llama.cpp' &&
                                 stepSetupRemoteProvider &&
@@ -264,7 +267,7 @@ const SettingsMenu = () => {
                     key={provider.provider}
                     className={cn(
                       'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-foreground',
-                      isRouteActive && 'bg-secondary',
+                      isRouteActive && 'bg-foreground/20',
                       provider.provider === 'llama.cpp' &&
                         stepSetupRemoteProvider &&
                         'hidden'
@@ -318,7 +321,7 @@ const SettingsMenu = () => {
                           key={provider.provider}
                           className={cn(
                             'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-muted-foreground',
-                            isRouteActive && 'bg-secondary'
+                            isRouteActive && 'bg-foreground/20'
                           )}
                           onClick={() =>
                             navigate({

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/components/ui/sidebar'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { memo, useMemo, useState } from 'react'
-import { Link } from '@tanstack/react-router'
+import { Link, useParams } from '@tanstack/react-router'
 import { RenameThreadDialog, DeleteThreadDialog } from '@/containers/dialogs'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
@@ -40,11 +40,13 @@ const WELCOME_THREAD_TITLES = new Set([
 const ThreadItem = memo(
   ({
     thread,
+    isActive,
     isMobile,
     currentProjectId,
     subItem,
   }: {
     thread: Thread
+    isActive: boolean
     isMobile: boolean
     currentProjectId?: string
     subItem?: boolean
@@ -161,7 +163,10 @@ const ThreadItem = memo(
           <Link
             to="/threads/$threadId"
             params={{ threadId: thread.id }}
-            className="bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block"
+            className={cn(
+              'bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block',
+              isActive && 'bg-secondary dark:bg-secondary/80'
+            )}
           >
             <span>{thread.title || t('common:newThread')}</span>
             {currentProjectId && lastUserMessageText && (
@@ -171,7 +176,11 @@ const ThreadItem = memo(
             )}
           </Link>
         ) : (
-          <MenuButtonWrapper asChild>
+          <MenuButtonWrapper
+            asChild
+            isActive={isActive}
+            className="data-[active=true]:bg-sidebar-foreground/15"
+          >
             <Link to="/threads/$threadId" params={{ threadId: thread.id }}>
               <span>{thread.title || t('common:newThread')}</span>
             </Link>
@@ -305,6 +314,10 @@ type ThreadListProps = {
 
 function ThreadList({ threads, currentProjectId, subItem }: ThreadListProps) {
   const { isMobile } = useSidebar()
+  // The open thread is the source of truth for "selected", read straight from
+  // the route params. Computed once here (not per row) so only the previously
+  // and newly active rows re-render when navigating between threads.
+  const { threadId: activeThreadId } = useParams({ strict: false })
 
   const sortedThreads = useMemo(() => {
     return [...threads].sort((a, b) => {
@@ -318,6 +331,7 @@ function ThreadList({ threads, currentProjectId, subItem }: ThreadListProps) {
         <ThreadItem
           key={thread.id}
           thread={thread}
+          isActive={thread.id === activeThreadId}
           isMobile={isMobile}
           currentProjectId={currentProjectId}
           subItem={subItem}

--- a/web-app/src/containers/__tests__/ThreadList.test.tsx
+++ b/web-app/src/containers/__tests__/ThreadList.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useParams } from '@tanstack/react-router'
+import ThreadList from '../ThreadList'
+
+// Render Link as a plain anchor, forwarding any extra props (e.g. the
+// data-active / className the sidebar button merges onto it).
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, params, className, ...props }: any) => (
+    <a
+      href={typeof to === 'string' ? to : '#'}
+      className={className}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  useParams: vi.fn(),
+}))
+
+// Lightweight sidebar mock that surfaces `isActive` as `data-active` so the
+// test asserts the real wiring without pulling in the full sidebar context.
+vi.mock('@/components/ui/sidebar', () => ({
+  useSidebar: () => ({ isMobile: false }),
+  SidebarMenuItem: ({ children, className }: any) => (
+    <li className={className}>{children}</li>
+  ),
+  SidebarMenuSubItem: ({ children, className }: any) => (
+    <li className={className}>{children}</li>
+  ),
+  SidebarMenuButton: ({ children, isActive }: any) => (
+    <div data-testid="thread-button" data-active={String(!!isActive)}>
+      {children}
+    </div>
+  ),
+  SidebarMenuSubButton: ({ children, isActive }: any) => (
+    <div data-testid="thread-button" data-active={String(!!isActive)}>
+      {children}
+    </div>
+  ),
+  SidebarMenuAction: ({ children }: any) => (
+    <button type="button">{children}</button>
+  ),
+}))
+
+// Dropdown menu and dialogs are not under test — collapse them to passthroughs.
+vi.mock('@/components/ui/dropdown-menu', () => {
+  const Pass = ({ children }: any) => <div>{children}</div>
+  return {
+    DropdownMenu: Pass,
+    DropdownMenuContent: Pass,
+    DropdownMenuItem: Pass,
+    DropdownMenuSeparator: Pass,
+    DropdownMenuTrigger: Pass,
+    DropdownMenuSub: Pass,
+    DropdownMenuSubContent: Pass,
+    DropdownMenuSubTrigger: Pass,
+  }
+})
+
+vi.mock('@/containers/dialogs', () => ({
+  RenameThreadDialog: () => null,
+  DeleteThreadDialog: () => null,
+}))
+
+vi.mock('@/i18n/react-i18next-compat', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/hooks/useThreads', () => ({
+  useThreads: (selector: any) =>
+    selector({
+      deleteThread: vi.fn(),
+      renameThread: vi.fn(),
+      updateThread: vi.fn(),
+    }),
+}))
+
+vi.mock('@/hooks/useMessages', () => ({
+  useMessages: (selector: any) =>
+    selector({
+      getMessages: () => [],
+      setMessages: vi.fn(),
+    }),
+}))
+
+vi.mock('@/hooks/useThreadManagement', () => ({
+  useThreadManagement: () => ({ getFolderById: vi.fn(), folders: [] }),
+}))
+
+vi.mock('@/hooks/useServiceHub', () => ({
+  useServiceHub: () => ({
+    messages: () => ({ fetchMessages: () => Promise.resolve([]) }),
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('@janhq/core', () => ({}))
+
+const threads: Thread[] = [
+  { id: 'thread-1', title: 'First chat', updated: 2 },
+  { id: 'thread-2', title: 'Second chat', updated: 1 },
+]
+
+describe('ThreadList active highlight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('marks the open thread active and the others inactive', async () => {
+    vi.mocked(useParams).mockReturnValue({ threadId: 'thread-1' } as never)
+
+    await act(async () => {
+      render(<ThreadList threads={threads} />)
+    })
+
+    const activeButton = screen
+      .getByText('First chat')
+      .closest('[data-testid="thread-button"]')
+    const inactiveButton = screen
+      .getByText('Second chat')
+      .closest('[data-testid="thread-button"]')
+
+    expect(activeButton).toHaveAttribute('data-active', 'true')
+    expect(inactiveButton).toHaveAttribute('data-active', 'false')
+  })
+
+  it('marks no thread active when not on a thread route', async () => {
+    vi.mocked(useParams).mockReturnValue({} as never)
+
+    await act(async () => {
+      render(<ThreadList threads={threads} />)
+    })
+
+    screen
+      .getAllByTestId('thread-button')
+      .forEach((button) =>
+        expect(button).toHaveAttribute('data-active', 'false')
+      )
+  })
+
+  it('highlights the open thread card inside a project', async () => {
+    vi.mocked(useParams).mockReturnValue({ threadId: 'thread-2' } as never)
+
+    await act(async () => {
+      render(<ThreadList threads={threads} currentProjectId="project-1" />)
+    })
+
+    const activeCard = screen.getByText('Second chat').closest('a')
+    const inactiveCard = screen.getByText('First chat').closest('a')
+
+    // Selected card gets the full `bg-secondary` accent (the project's
+    // selected convention); match the exact token so the base
+    // `dark:bg-secondary/20` doesn't give a false positive.
+    expect(activeCard?.className.split(' ')).toContain('bg-secondary')
+    expect(inactiveCard?.className.split(' ')).not.toContain('bg-secondary')
+  })
+})


### PR DESCRIPTION
## Describe Your Changes

The selected item wasn't clearly indicated in the app's navigation menus, so it
was easy to lose track of where you were. Two problems:

1. The selected state often wasn't set at all — the sidebar's `SidebarMenuButton`
   already supports `isActive`, it just was never passed for chats or nav pages.
2. Where it was set, it used an absolute `bg-secondary`, which has almost no
   contrast against the sidebar's own background — so the "selected" highlight was
   nearly invisible (especially in light mode) and weaker than the hover state.

This makes the selected highlight a **background-relative** overlay so it's always
legible and always reads stronger than hover, applied consistently across the
navigation surfaces:

- **Chats** (`ThreadList`) — the open thread, in the sidebar and in project cards.
- **Sidebar nav** (`NavMain`) — Models, Integrations and Settings highlight while
  their page is open (Settings across its sub-pages). Action items (New Chat, New
  Projects, Search) don't highlight, since they trigger an action rather than
  navigate to a persistent page.
- **Settings menu** (`SettingsMenu`) — the selected settings category.

Each surface uses an overlay relative to its own background (the sidebar's
`…-foreground` token for sidebar rows, the panel `foreground` token for the
settings menu), so they land at the same visual strength. No new dependencies.
Added unit tests for the active/inactive states of the chat list and nav menu.

### Before / After (sidebar)

| Before | After |
| --- | --- |
| <img width="1200" height="800" alt="atomic-chat-sidebar-before" src="https://github.com/user-attachments/assets/1a0a001a-d893-4ef1-8d90-defda7ea5066" /> | <img width="1200" height="800" alt="atomic-chat-sidebar-after" src="https://github.com/user-attachments/assets/46033580-219b-4761-b00c-9a0aa7358cf4" /> |

> Note: `SettingsMenu`'s `renders all menu items` test has a pre-existing failure
> unrelated to this change — it asserts the commented-out Privacy tab and fails the
> same way on `main`. Left as-is to keep this PR focused.

## Fixes Issues

_No linked issue — UX/accessibility fix._

## Follow-up

The same low-contrast pattern (absolute `secondary` overlays that don't hold up
against their background) appears elsewhere too — e.g. the model-selector dropdown.
I'd like to follow this up with a separate, comprehensive PR that audits and fixes
the contrast-deficient surfaces across the app. Tracked in #107.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features) — n/a, no behaviour to document
- [x] Created issues for follow-up changes or refactoring needed — #107 (app-wide contrast pass)
