### PR TITLE
fix(server): collapse system messages on anthropic /messages path (Claude Code + strict templates)

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -176,6 +176,20 @@ fn transform_anthropic_to_openai(body: &serde_json::Value) -> Option<serde_json:
 
     let openai_messages = convert_messages(messages, body.get("system"))?;
 
+    // Strict chat templates (e.g. AtomicChat/ornith-9b, Qwen3-family GGUFs)
+    // `raise` "System message must be at the beginning" whenever a request
+    // carries more than one system message or a non-leading one. Claude Code
+    // triggers this by combining its system prompt with developer/system items,
+    // and the failure surfaces during llama.cpp's tool-call parser generation.
+    // Collapse them into a single leading system message — the same fix already
+    // applied on the Codex `/responses` path (see responses_shim).
+    let openai_messages = match openai_messages.as_array() {
+        Some(arr) => serde_json::Value::Array(super::responses_shim::merge_system_messages(
+            arr.clone(),
+        )),
+        None => openai_messages,
+    };
+
     let stream = body
         .get("stream")
         .and_then(|v| v.as_bool())

--- a/src-tauri/src/core/server/responses_shim.rs
+++ b/src-tauri/src/core/server/responses_shim.rs
@@ -111,7 +111,10 @@ pub fn responses_request_to_chat(body: &Value) -> Value {
 /// than one system message or places one after the first turn — which Codex
 /// readily does by combining `instructions` with developer/system input items.
 /// Order of the remaining (non-system) messages is preserved.
-fn merge_system_messages(messages: Vec<Value>) -> Vec<Value> {
+///
+/// Also reused by the Anthropic `/messages` proxy path (Claude Code), which can
+/// likewise emit more than one system message after conversion.
+pub(crate) fn merge_system_messages(messages: Vec<Value>) -> Vec<Value> {
     let mut system_parts: Vec<String> = Vec::new();
     let mut rest: Vec<Value> = Vec::with_capacity(messages.len());
 


### PR DESCRIPTION
## Summary

- Collapse multiple system messages into a single leading system message on the Anthropic `/messages` proxy path (same behavior already used on the Codex `/responses` shim).
- Reuse `merge_system_messages` from `responses_shim.rs` in `proxy.rs` so Claude Code requests that combine system prompts with developer/system items no longer fail strict chat templates (e.g. AtomicChat/ornith-9b, Qwen3-family GGUFs) with "System message must be at the beginning".

## Context

Claude Code can emit more than one system message after Anthropic→OpenAI conversion. Strict templates reject non-leading or duplicate system roles, which surfaces during llama.cpp tool-call parser generation.

## Test plan

- [ ] Send a Claude Code request through Atomic Chat's Anthropic `/messages` endpoint against a strict-template model
- [ ] Confirm tool-call / streaming responses succeed without "System message must be at the beginning"
- [ ] Verify Codex `/responses` path behavior is unchanged


Made with [Cursor](https://cursor.com)