### PR TITLE
fix(ui): improve selected and hover contrast across the app

### DIFF
--- a/web-app/src/components/ui/button.tsx
+++ b/web-app/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary rounded-full text-secondary-foreground hover:bg-secondary/80",
         ghost:
-          "hover:bg-accent rounded-full hover:text-accent-foreground dark:hover:bg-accent/50",
+          "hover:bg-foreground/10 rounded-full hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/web-app/src/components/ui/dialog.tsx
+++ b/web-app/src/components/ui/dialog.tsx
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-foreground/10 data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/web-app/src/components/ui/dropdown-menu.tsx
+++ b/web-app/src/components/ui/dropdown-menu.tsx
@@ -72,8 +72,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-foreground/10 focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
       )}
       {...props}
     />
@@ -90,8 +89,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-foreground/10 focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
       )}
       checked={checked}
       {...props}
@@ -126,8 +124,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-foreground/10 focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
       )}
       {...props}
     >
@@ -209,8 +206,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-foreground/10 focus:text-accent-foreground data-[state=open]:bg-foreground/10 data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
       )}
       {...props}
     >

--- a/web-app/src/components/ui/dropdown-menu.tsx
+++ b/web-app/src/components/ui/dropdown-menu.tsx
@@ -72,7 +72,8 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-foreground/10 focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
+        "focus:bg-foreground/10 focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
       )}
       {...props}
     />
@@ -89,7 +90,8 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-foreground/10 focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
+        "focus:bg-foreground/10 focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
       )}
       checked={checked}
       {...props}
@@ -124,7 +126,8 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-foreground/10 focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
+        "focus:bg-foreground/10 focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
       )}
       {...props}
     >
@@ -206,7 +209,8 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-foreground/10 focus:text-accent-foreground data-[state=open]:bg-foreground/10 data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",        className
+        "focus:bg-foreground/10 focus:text-accent-foreground data-[state=open]:bg-foreground/10 data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
       )}
       {...props}
     >

--- a/web-app/src/components/ui/dropdrawer.tsx
+++ b/web-app/src/components/ui/dropdrawer.tsx
@@ -298,7 +298,7 @@ function DropDrawerContent({
                 <div className="flex items-center gap-2">
                   <button
                     onClick={goBack}
-                    className="hover:bg-muted/50 rounded-full p-1"
+                    className="hover:bg-foreground/10 rounded-full p-1"
                   >
                     <ChevronLeftIcon className="size-5" />
                   </button>

--- a/web-app/src/containers/AgentApprovalModeSelect.tsx
+++ b/web-app/src/containers/AgentApprovalModeSelect.tsx
@@ -37,7 +37,7 @@ export function AgentApprovalModeSelect({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={selectedLabel}
         >
           {mode === 'manual' ? (

--- a/web-app/src/containers/AgentExternalFolderButton.tsx
+++ b/web-app/src/containers/AgentExternalFolderButton.tsx
@@ -34,7 +34,7 @@ export function AgentExternalFolderButton({
   return (
     <button
       type="button"
-      className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       title={t('agentWorkspace.addFolder')}
       aria-label={t('agentWorkspace.addFolder')}
       onClick={() => void addFolder()}

--- a/web-app/src/containers/AgentSkillSlashMenu.tsx
+++ b/web-app/src/containers/AgentSkillSlashMenu.tsx
@@ -49,8 +49,8 @@ export function AgentSkillSlashMenu({
               aria-selected={index === activeIndex}
               className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left ${
                 index === activeIndex
-                  ? 'bg-accent text-accent-foreground'
-                  : 'hover:bg-accent/60'
+                  ? 'bg-foreground/20 text-accent-foreground'
+                  : 'hover:bg-foreground/10'
               }`}
               onMouseDown={(event) => event.preventDefault()}
               onMouseEnter={() => onActiveIndexChange(index)}

--- a/web-app/src/containers/AgentSkillUploadDialog.tsx
+++ b/web-app/src/containers/AgentSkillUploadDialog.tsx
@@ -94,7 +94,7 @@ export function AgentSkillUploadDialog({
           disabled={submitting}
           className={cn(
             'h-56 w-full flex-col gap-5 rounded-lg border border-dashed text-muted-foreground',
-            dragging && 'border-primary bg-accent text-foreground'
+            dragging && 'border-primary bg-foreground/10 text-foreground'
           )}
           onClick={() => void chooseFile()}
           onDragEnter={(event) => {

--- a/web-app/src/containers/AgentTaskSuggestions.tsx
+++ b/web-app/src/containers/AgentTaskSuggestions.tsx
@@ -46,7 +46,7 @@ export function AgentTaskSuggestions({
               key={task.id}
               type="button"
               onClick={() => onSelect(t(task.promptKey))}
-              className="group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg px-1 py-1.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg px-1 py-1.5 text-left transition-colors hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border/80 text-muted-foreground/80">
                 <TaskIcon

--- a/web-app/src/containers/AgentWorkspaceLayout.tsx
+++ b/web-app/src/containers/AgentWorkspaceLayout.tsx
@@ -219,7 +219,7 @@ export function AgentWorkspaceLayout({
       {!filesVisible && (
         <button
           type="button"
-          className="absolute top-[17px] right-3 z-30 flex size-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground outline-none ring-ring transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2"
+          className="absolute top-[17px] right-3 z-30 flex size-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground outline-none ring-ring transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:ring-2"
           aria-label="Open files sidebar"
           title="Open files sidebar"
           onClick={() => setFilesOpen(true)}

--- a/web-app/src/containers/AgentWorkspacePreview.tsx
+++ b/web-app/src/containers/AgentWorkspacePreview.tsx
@@ -188,7 +188,7 @@ export function AgentWorkspacePreview({
               </button>
               <button
                 type="button"
-                className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded opacity-60 hover:bg-accent hover:opacity-100"
+                className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded opacity-60 hover:bg-foreground/10 hover:opacity-100"
                 aria-label={`Close ${tab.name}`}
                 onClick={() => close(tab.id)}
               >

--- a/web-app/src/containers/AgentWorkspaceSelect.tsx
+++ b/web-app/src/containers/AgentWorkspaceSelect.tsx
@@ -36,7 +36,7 @@ export function AgentWorkspaceSelect({
   return (
     <button
       type="button"
-      className="flex max-w-48 cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="flex max-w-48 cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       title={workingDir ?? t('agentWorkspace.defaultDescription')}
       aria-label={
         workingDir ? t('agentWorkspace.change') : t('agentWorkspace.choose')

--- a/web-app/src/containers/ApiKeyInput.tsx
+++ b/web-app/src/containers/ApiKeyInput.tsx
@@ -81,7 +81,7 @@ export function ApiKeyInput({
       <div className="absolute right-2 top-1/2 transform -translate-y-1/2 flex items-center gap-1">
         <button
           onClick={() => setShowPassword(!showPassword)}
-          className="p-1 rounded hover:bg-secondary/50 text-muted-foreground"
+          className="p-1 rounded hover:bg-foreground/10 text-muted-foreground"
           type="button"
         >
           {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}

--- a/web-app/src/containers/AttachmentChip.tsx
+++ b/web-app/src/containers/AttachmentChip.tsx
@@ -84,7 +84,7 @@ export const AttachmentChip = ({
           className={cn(
             'group/chip relative flex items-center gap-3 pl-2 py-1.5 rounded-2xl w-[220px] transition-colors',
             showRemove ? 'pr-7' : 'pr-3',
-            !hasError && 'bg-muted/50 hover:bg-muted',
+            !hasError && 'bg-muted/50 hover:bg-foreground/10',
             hasError && 'bg-destructive/10 hover:bg-destructive/15',
             className
           )}

--- a/web-app/src/containers/AudioPlayer.tsx
+++ b/web-app/src/containers/AudioPlayer.tsx
@@ -244,7 +244,7 @@ export function AudioPlayer({
             <button
               type="button"
               aria-label="Playback options"
-              className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground"
+              className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-foreground/10 hover:text-foreground"
             >
               <IconDots size={16} />
             </button>

--- a/web-app/src/containers/Capabilities.tsx
+++ b/web-app/src/containers/Capabilities.tsx
@@ -54,7 +54,7 @@ const Capabilities = memo(function Capabilities({ capabilities }: CapabilitiesPr
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
-                      className="flex items-center gap-1 size-5 hover:bg-secondary rounded text-muted-foreground justify-center last:mr-1 transition-all"
+                      className="flex items-center gap-1 size-5 hover:bg-foreground/10 rounded text-muted-foreground justify-center last:mr-1 transition-all"
                       title={capability}
                     >
                       {icon}

--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -753,7 +753,7 @@ export function DownloadManagement() {
                           {isPausableDownload(download.id) &&
                             (pausedDownloads.has(download.id) ? (
                               <Button
-                                variant="secondary"
+                                variant="ghost"
                                 size="icon-xs"
                                 onClick={() => handleResumeDownload(download)}
                               >
@@ -765,7 +765,7 @@ export function DownloadManagement() {
                               </Button>
                             ) : (
                               <Button
-                                variant="secondary"
+                                variant="ghost"
                                 size="icon-xs"
                                 onClick={() => handlePauseDownload(download)}
                               >
@@ -777,7 +777,7 @@ export function DownloadManagement() {
                               </Button>
                             ))}
                           <Button
-                            variant="secondary"
+                            variant="ghost"
                             size="icon-xs"
                             onClick={() => {
                               markDownloadCancellationRequested(download.name)

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -666,7 +666,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
                           onClick={() => handleSelect(searchableModel)}
                           className={cn(
                             'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
-                            'hover:bg-secondary/40',
+                            'hover:bg-foreground/10',
                             isSelected && 'bg-foreground/20 hover:bg-foreground/20'
                           )}
                         >
@@ -772,7 +772,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
                               onClick={() => handleSelect(searchableModel)}
                               className={cn(
                                 'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
-                                'hover:bg-secondary/40',
+                                'hover:bg-foreground/10',
                                 isSelected &&
                                   'bg-foreground/20 hover:bg-foreground/20'
                               )}
@@ -820,7 +820,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
             <button
               type="button"
               onClick={onDownloadModel}
-              className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm cursor-pointer text-sm text-muted-foreground transition-colors duration-200 hover:bg-secondary/40 hover:text-foreground"
+              className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm cursor-pointer text-sm text-muted-foreground transition-colors duration-200 hover:bg-foreground/10 hover:text-foreground"
             >
               <IconDownload size={16} className="shrink-0" />
               <span>{t('common:downloadModel')}</span>

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -667,7 +667,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
                           className={cn(
                             'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
                             'hover:bg-secondary/40',
-                            isSelected && 'bg-secondary/50'
+                            isSelected && 'bg-foreground/20 hover:bg-foreground/20'
                           )}
                         >
                           <div className="flex items-center gap-1 flex-1 min-w-0">
@@ -774,7 +774,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
                                 'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
                                 'hover:bg-secondary/40',
                                 isSelected &&
-                                  'bg-secondary/60 hover:bg-secondary/60'
+                                  'bg-foreground/20 hover:bg-foreground/20'
                               )}
                             >
                               <div className="flex items-center gap-2 flex-1 min-w-0">

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -667,7 +667,8 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
                           className={cn(
                             'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
                             'hover:bg-foreground/10',
-                            isSelected && 'bg-foreground/20 hover:bg-foreground/20'
+                            isSelected &&
+                              'bg-foreground/20 hover:bg-foreground/20'
                           )}
                         >
                           <div className="flex items-center gap-1 flex-1 min-w-0">

--- a/web-app/src/containers/ModelCombobox.tsx
+++ b/web-app/src/containers/ModelCombobox.tsx
@@ -157,8 +157,8 @@ const ModelsList = ({
         onMouseEnter={() => onHighlight(index)}
         className={cn(
           'cursor-pointer mx-3 px-2 rounded-md py-2 bg-background z-20 transition-all duration-200',
-          value === model && 'bg-secondary shadow-sm',
-          highlightedIndex === index && ' bg-secondary'
+          value === model && 'bg-foreground/20 shadow-sm',
+          highlightedIndex === index && ' bg-foreground/10'
         )}
       >
         <span className="text-sm truncate text-foreground">{model}</span>

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -479,7 +479,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
             'flex flex-col items-center justify-center py-8 px-4 rounded-lg border border-dashed cursor-pointer transition-colors',
             isDragging
               ? 'bg-primary/10 border-primary'
-              : 'bg-secondary/30 border-border hover:bg-secondary/50'
+              : 'bg-secondary/30 border-border hover:bg-foreground/10'
           )}
           onClick={handleUpload}
           onDragOver={handleDragOver}
@@ -507,7 +507,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
               className={cn(
                 'flex items-center gap-2 p-2 rounded-lg',
                 'bg-secondary/30 border border-border/50',
-                'group hover:bg-secondary/50 transition-colors'
+                'group hover:bg-foreground/10 transition-colors'
               )}
             >
               <div className="shrink-0">
@@ -544,7 +544,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
             'flex mt-2 flex-col items-center justify-center py-8 px-4 rounded-lg border border-dashed cursor-pointer transition-colors',
             isDragging
               ? 'bg-primary/10 border-primary'
-              : 'bg-secondary/30 border-border hover:bg-secondary/50'
+              : 'bg-secondary/30 border-border hover:bg-foreground/10'
           )}
           onClick={handleUpload}
           onDragOver={handleDragOver}

--- a/web-app/src/containers/SamplerPopover.tsx
+++ b/web-app/src/containers/SamplerPopover.tsx
@@ -155,7 +155,7 @@ export function SamplerPopover({ disabled }: SamplerPopoverProps) {
                 className="w-(--radix-dropdown-menu-trigger-width) max-h-64 overflow-y-auto"
               >
                 <DropdownMenuItem
-                  className={!activeAssistant ? 'bg-accent' : ''}
+                  className={!activeAssistant ? 'bg-foreground/20' : ''}
                   onClick={() => handleSelectAssistant(undefined)}
                 >
                   <span className="text-muted-foreground">—</span>
@@ -166,7 +166,7 @@ export function SamplerPopover({ disabled }: SamplerPopoverProps) {
                     <DropdownMenuItem
                       key={assistant.id}
                       className={
-                        activeAssistant?.id === assistant.id ? 'bg-accent' : ''
+                        activeAssistant?.id === assistant.id ? 'bg-foreground/20' : ''
                       }
                       onClick={() => handleSelectAssistant(assistant)}
                     >

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -168,7 +168,7 @@ const SettingsMenu = () => {
                     matching the sidebar's selected treatment. */}
                 <Link
                   to={menu.route}
-                  className="block px-2 gap-1.5 cursor-pointer hover:dark:bg-secondary/60 hover:bg-secondary py-1 w-full rounded-sm [&.active]:bg-foreground/20"
+                  className="block px-2 gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm [&.active]:bg-foreground/20"
                 >
                   <div className="flex items-center justify-between">
                     <span>{t(menu.title)}</span>
@@ -207,7 +207,7 @@ const SettingsMenu = () => {
                         <div key={provider.provider}>
                           <div
                             className={cn(
-                              'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-foreground',
+                              'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm text-foreground',
                               isActive && 'bg-foreground/20',
                               // hidden for llama.cpp provider for setup remote provider
                               provider.provider === 'llama.cpp' &&
@@ -266,7 +266,7 @@ const SettingsMenu = () => {
                   <div
                     key={provider.provider}
                     className={cn(
-                      'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-foreground',
+                      'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm text-foreground',
                       isRouteActive && 'bg-foreground/20',
                       provider.provider === 'llama.cpp' &&
                         stepSetupRemoteProvider &&
@@ -293,7 +293,7 @@ const SettingsMenu = () => {
               {hiddenProviders.length > 0 && (
                 <>
                   <button
-                    className="flex items-center justify-between px-2 py-1 w-full rounded-sm text-muted-foreground hover:bg-secondary/60"
+                    className="flex items-center justify-between px-2 py-1 w-full rounded-sm text-muted-foreground hover:bg-foreground/10"
                     onClick={() => setExpandedProviders(!expandedProviders)}
                   >
                     <span className="text-sm">
@@ -320,7 +320,7 @@ const SettingsMenu = () => {
                         <div
                           key={provider.provider}
                           className={cn(
-                            'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-muted-foreground',
+                            'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm text-muted-foreground',
                             isRouteActive && 'bg-foreground/20'
                           )}
                           onClick={() =>

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -184,8 +184,8 @@ const ThreadItem = memo(
             to="/threads/$threadId"
             params={{ threadId: thread.id }}
             className={cn(
-              'bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block',
-              isActive && 'bg-secondary dark:bg-secondary/80'
+              'bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:bg-foreground/10 rounded-lg block',
+              isActive && 'bg-foreground/20'
             )}
           >
             <span className="flex items-center gap-2 pr-8 min-w-0">

--- a/web-app/src/containers/dialogs/AddCloudProviderDialog.tsx
+++ b/web-app/src/containers/dialogs/AddCloudProviderDialog.tsx
@@ -180,7 +180,7 @@ export function AddCloudProviderDialog({
                       onClick={() => setStep({ name: 'key', provider })}
                       className={cn(
                         'flex items-center gap-3 rounded-lg border bg-secondary/50 p-3 text-left',
-                        'hover:bg-secondary focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none'
+                        'hover:bg-foreground/10 focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none'
                       )}
                     >
                       <ProvidersAvatar

--- a/web-app/src/containers/dialogs/AddEditCustomCliDialog.tsx
+++ b/web-app/src/containers/dialogs/AddEditCustomCliDialog.tsx
@@ -113,7 +113,7 @@ export default function AddEditCustomCliDialog({
             <div className="flex items-center justify-between">
               <label className="text-sm">Environment Variables</label>
               <div
-                className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+                className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
                 onClick={handleAddEnv}
               >
                 <IconPlus size={16} className="text-muted-foreground" />
@@ -136,7 +136,7 @@ export default function AddEditCustomCliDialog({
                 />
                 {envVars.length > 1 && (
                   <div
-                    className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+                    className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
                     onClick={() => handleRemoveEnv(index)}
                   >
                     <IconTrash size={16} className="text-destructive" />

--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -388,7 +388,7 @@ export default function AddEditMCPServer({
             <div
               className={cn(
                 'size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out',
-                isToggled && 'bg-secondary text-primary'
+                isToggled && 'bg-foreground/20 text-primary'
               )}
               title="Add server by JSON"
               onClick={() => setIsToggled(!isToggled)}

--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -79,7 +79,7 @@ function SortableArgItem({
       <div
         {...attributes}
         {...listeners}
-        className="size-6 cursor-move flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+        className="size-6 cursor-move flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
       >
         <IconGripVertical size={16} className="text-muted-foreground" />
       </div>
@@ -91,7 +91,7 @@ function SortableArgItem({
       />
       {canRemove && (
         <div
-          className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+          className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
           onClick={onRemove}
         >
           <IconTrash size={16} className="text-destructive" />
@@ -387,7 +387,7 @@ export default function AddEditMCPServer({
             </span>
             <div
               className={cn(
-                'size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out',
+                'size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out',
                 isToggled && 'bg-secondary text-primary'
               )}
               title="Add server by JSON"
@@ -517,7 +517,7 @@ export default function AddEditMCPServer({
                     {t('mcp-servers:arguments')}
                   </label>
                   <div
-                    className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+                    className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
                     onClick={handleAddArg}
                   >
                     <IconPlus size={16} className="text-muted-foreground" />
@@ -563,7 +563,7 @@ export default function AddEditMCPServer({
                 <div className="flex items-center justify-between">
                   <label className="text-sm">{t('mcp-servers:envVars')}</label>
                   <div
-                    className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+                    className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
                     onClick={handleAddEnv}
                   >
                     <IconPlus size={16} className="text-muted-foreground" />
@@ -590,7 +590,7 @@ export default function AddEditMCPServer({
                     />
                     {envKeys.length > 1 && (
                       <div
-                        className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+                        className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
                         onClick={() => handleRemoveEnv(index)}
                       >
                         <IconTrash size={16} className="text-destructive" />
@@ -607,7 +607,7 @@ export default function AddEditMCPServer({
                   <div className="flex items-center justify-between">
                     <label className="text-sm">Headers</label>
                     <div
-                      className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+                      className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
                       onClick={handleAddHeader}
                     >
                       <IconPlus size={16} className="text-muted-foreground" />
@@ -637,7 +637,7 @@ export default function AddEditMCPServer({
                       />
                       {headerKeys.length > 1 && (
                         <div
-                          className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-secondary transition-all duration-200 ease-in-out"
+                          className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-foreground/10 transition-all duration-200 ease-in-out"
                           onClick={() => handleRemoveHeader(index)}
                         >
                           <IconTrash size={16} className="text-destructive" />

--- a/web-app/src/containers/dialogs/DeleteModel.tsx
+++ b/web-app/src/containers/dialogs/DeleteModel.tsx
@@ -81,7 +81,7 @@ export const DialogDeleteModel = ({
     <Dialog>
       <DialogTrigger asChild>
         <div
-          className="size-6 cursor-pointer flex items-center justify-center rounded transition-all duration-200 ease-in-out"
+          className="size-6 cursor-pointer flex items-center justify-center rounded transition-all duration-200 ease-in-out hover:bg-foreground/10"
           title={t('providers:deleteModel.delete')}
           aria-label={t('providers:deleteModel.delete')}
         >

--- a/web-app/src/containers/dialogs/EditModel.tsx
+++ b/web-app/src/containers/dialogs/EditModel.tsx
@@ -180,7 +180,7 @@ export const DialogEditModel = ({
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogChange}>
       <DialogTrigger asChild>
-        <div className="size-6 cursor-pointer flex items-center justify-center rounded transition-all duration-200 ease-in-out">
+        <div className="size-6 cursor-pointer flex items-center justify-center rounded transition-all duration-200 ease-in-out hover:bg-foreground/10">
           <IconPencil size={18} className="text-muted-foreground" />
         </div>
       </DialogTrigger>

--- a/web-app/src/containers/dialogs/SearchDialog.tsx
+++ b/web-app/src/containers/dialogs/SearchDialog.tsx
@@ -272,7 +272,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                 data-index={0}
                 onClick={handleStartNewChat}
                 className={cn(
-                  'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
+                  'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
                   selectedIndex === 0 && 'bg-foreground/20 hover:bg-foreground/20'
                 )}
               >
@@ -304,7 +304,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     data-index={itemIndex}
                     onClick={() => handleSelectThread(thread.id)}
                     className={cn(
-                      'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
+                      'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
                       selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
                     )}
                   >
@@ -328,7 +328,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                       data-index={itemIndex}
                       onClick={() => handleSelectThread(thread.id)}
                       className={cn(
-                        'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
+                        'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
                         selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
                       )}
                     >
@@ -343,8 +343,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     </button>
                   )
                 }
-              )}            </div>
-          )}
+              )}            </div>          )}
 
           {/* Search results without project name */}
           {searchQuery && searchResults.withoutProject.length > 0 && (
@@ -357,7 +356,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     data-index={itemIndex}
                     onClick={() => handleSelectThread(thread.id)}
                     className={cn(
-                      'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
+                      'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
                       selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
                     )}
                   >

--- a/web-app/src/containers/dialogs/SearchDialog.tsx
+++ b/web-app/src/containers/dialogs/SearchDialog.tsx
@@ -273,7 +273,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                 onClick={handleStartNewChat}
                 className={cn(
                   'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
-                  selectedIndex === 0 && 'bg-secondary/50'
+                  selectedIndex === 0 && 'bg-foreground/20 hover:bg-foreground/20'
                 )}
               >
                 <IconCirclePlus className="size-4 text-muted-foreground" />
@@ -305,7 +305,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     onClick={() => handleSelectThread(thread.id)}
                     className={cn(
                       'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
-                      selectedIndex === itemIndex && 'bg-secondary/50'
+                      selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
                     )}
                   >
                     <IconHistory className="size-4 text-muted-foreground shrink-0" />
@@ -329,7 +329,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                       onClick={() => handleSelectThread(thread.id)}
                       className={cn(
                         'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
-                        selectedIndex === itemIndex && 'bg-secondary/50'
+                        selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
                       )}
                     >
                       <IconMessage className="size-4 text-muted-foreground shrink-0" />
@@ -343,8 +343,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     </button>
                   )
                 }
-              )}
-            </div>
+              )}            </div>
           )}
 
           {/* Search results without project name */}
@@ -359,7 +358,7 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     onClick={() => handleSelectThread(thread.id)}
                     className={cn(
                       'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
-                      selectedIndex === itemIndex && 'bg-secondary/50'
+                      selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
                     )}
                   >
                     <IconMessage className="size-4 text-muted-foreground shrink-0" />

--- a/web-app/src/containers/dialogs/SearchDialog.tsx
+++ b/web-app/src/containers/dialogs/SearchDialog.tsx
@@ -273,7 +273,8 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                 onClick={handleStartNewChat}
                 className={cn(
                   'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
-                  selectedIndex === 0 && 'bg-foreground/20 hover:bg-foreground/20'
+                  selectedIndex === 0 &&
+                    'bg-foreground/20 hover:bg-foreground/20'
                 )}
               >
                 <IconCirclePlus className="size-4 text-muted-foreground" />
@@ -305,7 +306,8 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     onClick={() => handleSelectThread(thread.id)}
                     className={cn(
                       'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
-                      selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
+                      selectedIndex === itemIndex &&
+                        'bg-foreground/20 hover:bg-foreground/20'
                     )}
                   >
                     <IconHistory className="size-4 text-muted-foreground shrink-0" />
@@ -329,7 +331,8 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                       onClick={() => handleSelectThread(thread.id)}
                       className={cn(
                         'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
-                        selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
+                        selectedIndex === itemIndex &&
+                          'bg-foreground/20 hover:bg-foreground/20'
                       )}
                     >
                       <IconMessage className="size-4 text-muted-foreground shrink-0" />
@@ -343,7 +346,9 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     </button>
                   )
                 }
-              )}            </div>          )}
+              )}{' '}
+            </div>
+          )}
 
           {/* Search results without project name */}
           {searchQuery && searchResults.withoutProject.length > 0 && (
@@ -357,7 +362,8 @@ export function SearchDialog({ open, onOpenChange, mode }: SearchDialogProps) {
                     onClick={() => handleSelectThread(thread.id)}
                     className={cn(
                       'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-foreground/10 transition-colors cursor-pointer',
-                      selectedIndex === itemIndex && 'bg-foreground/20 hover:bg-foreground/20'
+                      selectedIndex === itemIndex &&
+                        'bg-foreground/20 hover:bg-foreground/20'
                     )}
                   >
                     <IconMessage className="size-4 text-muted-foreground shrink-0" />

--- a/web-app/src/containers/dialogs/SecurityConfigDialog.tsx
+++ b/web-app/src/containers/dialogs/SecurityConfigDialog.tsx
@@ -409,7 +409,7 @@ export function SecurityConfigDialog({
           className="space-y-2"
           disabled={isChangingAuthMode}
         >
-          <div className="flex items-center space-x-3 p-3 rounded-lg border border-border hover:bg-secondary/30 transition-colors">
+          <div className="flex items-center space-x-3 p-3 rounded-lg border border-border hover:bg-foreground/10 transition-colors">
             <RadioGroupItem value="token" id="auth-token" />
             <label htmlFor="auth-token" className="flex-1 cursor-pointer">
               <span className="font-medium text-foreground">Token</span>
@@ -418,7 +418,7 @@ export function SecurityConfigDialog({
               </p>
             </label>
           </div>
-          <div className="flex items-center space-x-3 p-3 rounded-lg border border-border hover:bg-secondary/30 transition-colors">
+          <div className="flex items-center space-x-3 p-3 rounded-lg border border-border hover:bg-foreground/10 transition-colors">
             <RadioGroupItem value="password" id="auth-password" />
             <label htmlFor="auth-password" className="flex-1 cursor-pointer">
               <span className="font-medium text-foreground">Password</span>
@@ -427,7 +427,7 @@ export function SecurityConfigDialog({
               </p>
             </label>
           </div>
-          <div className="flex items-center space-x-3 p-3 rounded-lg border border-border hover:bg-secondary/30 transition-colors">
+          <div className="flex items-center space-x-3 p-3 rounded-lg border border-border hover:bg-foreground/10 transition-colors">
             <RadioGroupItem value="none" id="auth-none" />
             <label htmlFor="auth-none" className="flex-1 cursor-pointer">
               <span className="font-medium text-foreground">None</span>

--- a/web-app/src/containers/dynamicControllerSetting/DropdownControl.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/DropdownControl.tsx
@@ -45,7 +45,7 @@ export function DropdownControl({
             className={cn(
               'flex items-center justify-between my-1',
               isSelected === option.name
-                ? 'bg-secondary/60 hover:bg-secondary/40'
+                ? 'bg-foreground/20 hover:bg-foreground/20'
                 : ''
             )}
           >

--- a/web-app/src/containers/hub/DownloadOptionsSelect.tsx
+++ b/web-app/src/containers/hub/DownloadOptionsSelect.tsx
@@ -154,7 +154,7 @@ export function DownloadOptionsSelect({
           type="button"
           onClick={() => setExpanded((prev) => !prev)}
           aria-expanded={expanded}
-          className="flex min-w-0 flex-1 items-center gap-2 rounded-md bg-muted/40 px-2 py-2 text-left hover:bg-muted/60"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md bg-muted/40 px-2 py-2 text-left hover:bg-foreground/10"
         >
           {fitKnown && <FitDot fit={selectedFit} />}
           <span className="shrink-0 rounded-[5px] bg-secondary px-[7px] py-0.5 font-mono text-[11px] font-semibold text-muted-foreground">
@@ -224,8 +224,8 @@ export function DownloadOptionsSelect({
                     quant.model_id === selected.model_id ? 'true' : undefined
                   }
                   className={cn(
-                    'flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left hover:bg-muted/40',
-                    quant.model_id === selected.model_id && 'bg-muted/60'
+                    'flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left hover:bg-foreground/10',
+                    quant.model_id === selected.model_id && 'bg-foreground/20'
                   )}
                 >
                   {fitKnown && <FitDot fit={fit} />}

--- a/web-app/src/containers/hub/HubFilters.tsx
+++ b/web-app/src/containers/hub/HubFilters.tsx
@@ -119,7 +119,7 @@ export function HubFilters({
               key={key}
               className={cn(
                 'my-0.5 cursor-pointer',
-                state.sort === key && 'bg-secondary'
+                state.sort === key && 'bg-foreground/20'
               )}
               onClick={() => onChange({ ...state, sort: key })}
             >

--- a/web-app/src/containers/hub/ModelListRow.tsx
+++ b/web-app/src/containers/hub/ModelListRow.tsx
@@ -40,8 +40,8 @@ export function ModelListRow({
       onClick={onSelect}
       aria-current={selected ? 'true' : undefined}
       className={cn(
-        'flex w-full items-center gap-3 rounded-lg border border-transparent px-2 py-3 text-left transition-colors hover:bg-accent',
-        selected && 'border-border bg-accent'
+        'flex w-full items-center gap-3 rounded-lg border border-transparent px-2 py-3 text-left transition-colors hover:bg-foreground/10',
+        selected && 'border-border bg-foreground/20'
       )}
     >
       <ModelLogo

--- a/web-app/src/routes/settings/assistant.tsx
+++ b/web-app/src/routes/settings/assistant.tsx
@@ -106,7 +106,7 @@ function AssistantContent() {
                           key={a.id}
                           className={cn(
                             'cursor-pointer my-0.5',
-                            defaultAssistantId === a.id && 'bg-secondary-foreground/8'
+                            defaultAssistantId === a.id && 'bg-foreground/20'
                           )}
                           onClick={() => setDefaultAssistant(a.id)}
                         >
@@ -120,7 +120,7 @@ function AssistantContent() {
               <h1 className="text-foreground font-studio font-medium text-sm mt-4 mb-4">{t('assistants:allAssistants')}</h1>
               {sortedAssistants.map((assistant) => (
                 <div
-                  className="group flex items-center gap-3 px-3 py-3 rounded-lg my-1 bg-secondary/20 hover:bg-secondary dark:hover:bg-secondary/20 transition-colors"
+                  className="group flex items-center gap-3 px-3 py-3 rounded-lg my-1 bg-secondary/20 hover:bg-foreground/10 transition-colors"
                   key={assistant.id}
                 >
                   <div className="size-9 shrink-0 flex items-center justify-center bg-secondary dark:bg-secondary/40 rounded-lg">

--- a/web-app/src/routes/settings/claude-code.tsx
+++ b/web-app/src/routes/settings/claude-code.tsx
@@ -528,7 +528,7 @@ function HelperModelSelector({
                               'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
                               'hover:bg-secondary/40',
                               isSelected &&
-                                'bg-secondary/60 hover:bg-secondary/60'
+                                'bg-foreground/20 hover:bg-foreground/20'
                             )}
                           >
                             <div className="flex items-center gap-2 flex-1 min-w-0">

--- a/web-app/src/routes/settings/claude-code.tsx
+++ b/web-app/src/routes/settings/claude-code.tsx
@@ -526,7 +526,7 @@ function HelperModelSelector({
                             onClick={() => handleSelect(model)}
                             className={cn(
                               'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
-                              'hover:bg-secondary/40',
+                              'hover:bg-foreground/10',
                               isSelected &&
                                 'bg-foreground/20 hover:bg-foreground/20'
                             )}

--- a/web-app/src/routes/settings/hermes-agent.tsx
+++ b/web-app/src/routes/settings/hermes-agent.tsx
@@ -371,7 +371,7 @@ function CopyableField({
         </code>
         <button
           onClick={copy}
-          className="shrink-0 p-0.5 rounded hover:bg-secondary/60 text-muted-foreground"
+          className="shrink-0 p-0.5 rounded hover:bg-foreground/10 text-muted-foreground"
         >
           {copied ? (
             <IconCheck size={13} className="text-emerald-500" />

--- a/web-app/src/routes/settings/hermes-agent.tsx
+++ b/web-app/src/routes/settings/hermes-agent.tsx
@@ -633,7 +633,7 @@ function ModelSelector({
                               'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
                               'hover:bg-secondary/40',
                               isSelected &&
-                                'bg-secondary/60 hover:bg-secondary/60'
+                                'bg-foreground/20 hover:bg-foreground/20'
                             )}
                           >
                             <div className="flex items-center gap-2 flex-1 min-w-0">

--- a/web-app/src/routes/settings/hermes-agent.tsx
+++ b/web-app/src/routes/settings/hermes-agent.tsx
@@ -631,7 +631,7 @@ function ModelSelector({
                             onClick={() => handleSelect(model)}
                             className={cn(
                               'mx-1 mb-1 px-2 py-1.5 rounded-sm cursor-pointer flex items-center gap-2 transition-all duration-200',
-                              'hover:bg-secondary/40',
+                              'hover:bg-foreground/10',
                               isSelected &&
                                 'bg-foreground/20 hover:bg-foreground/20'
                             )}

--- a/web-app/src/routes/skills/index.tsx
+++ b/web-app/src/routes/skills/index.tsx
@@ -156,8 +156,8 @@ export function SkillsPage() {
               <div
                 key={skill.name}
                 className={cn(
-                  'flex w-full items-center gap-2 rounded-lg border p-2 transition-colors hover:bg-accent',
-                  selected?.name === skill.name && 'bg-accent'
+                  'flex w-full items-center gap-2 rounded-lg border p-2 transition-colors hover:bg-foreground/10',
+                  selected?.name === skill.name && 'bg-foreground/20'
                 )}
               >
                 <button


### PR DESCRIPTION
## Describe Your Changes

A pass over the app's low-contrast selected/hover states. Several used an absolute
`bg-secondary` / `bg-accent` overlay, which collapses against light backgrounds
(both ≈`0.97` in light, nearly identical to the surfaces they sit on) — so the
state was hard to see, especially in light mode, and in places hover read as strong
as (or stronger than) the selection.

Everything moves to a **background-relative** `foreground` overlay so it stays
legible on any surface in both themes, with **hover (`/10`) a clear step below
selected (`/20`)**.

### Design decisions

- **Relative overlay, not an absolute token.** `bg-secondary`/`bg-accent` are ≈`0.97`
  in light — the same lightness as the surfaces behind them, so they vanish. A
  `foreground` overlay is a fixed *delta* from whatever is behind it, so it holds up
  on any surface and flips correctly between themes.
- **`/10` hover, `/20` selected.** Two fixed steps keep hover clearly below selected;
  before, several menus had them equal (or hover stronger).
- **Fixed at the source for shared components.** The `ghost` button variant and the
  base dropdown-menu item states are each changed once, so every ghost button (~80)
  and every dropdown inherits it rather than being patched per call site.
- **`outline` variant left alone** — it has a border, so its hover already reads fine.
- **Styling only** — no logic, state, or dependency changes.

**Selected states → `bg-foreground/20`**
- Model selector (`DropdownModelProvider`), search dialog (`SearchDialog`), Hermes
  Agent / Claude Code model rows, dropdown control (`DropdownControl`), assistant
  switcher (`SamplerPopover`). The search dialog's selected row was previously
  *lighter* than its hover — now clearly stronger.
- Hub sort dropdown (`hub/index`) and default-assistant picker (`settings/assistant`)
  — the selected item used `bg-secondary` (`0.97`), the exact same lightness as the
  menu hover, so selected and hovered items were indistinguishable.

**Hover states → `bg-foreground/10`**
- `ghost` button variant (`components/ui/button.tsx`) — `hover:bg-accent` was the
  faint hover on every ghost button (message copy/edit/delete/regenerate, header
  icons, menus, …). **Shared design-system change — affects all `variant="ghost"`
  buttons app-wide (~80 usages).** `outline` is left as-is (it has a border).
- Menu item highlight (`components/ui/dropdown-menu.tsx`) — the base
  `focus:bg-accent` / `data-[state=open]:bg-accent` states. **Also a shared
  design-system change — affects every dropdown menu app-wide**, and makes menu
  items hover consistently with ghost buttons.
- Settings menu (`SettingsMenu`) — category links used `hover:bg-secondary` while
  provider rows used `hover:bg-secondary/60` (mismatched and faint in light); unified.
- Model **edit / delete** trigger icons (`EditModel`, `DeleteModel`) — these had **no
  hover feedback at all**; added.
- Download panel pause / resume / cancel controls (`DownloadManegement`) — these were
  `variant="secondary"` on a `bg-secondary` row, so the button was the same shade as
  its surface and `hover:bg-secondary/80` only faded it further. Switched to `ghost`
  so they share the hover overlay and read on the row.
- A final sweep of the remaining faint row/icon hovers (`hover:bg-{muted,secondary}`
  at assorted opacities): hub model variant rows (`HubModelCard`), project file rows
  (`ProjectFiles`), security config rows (`SecurityConfigDialog`), assistant cards,
  and the small utility icon buttons in `AddEditMCPServer`, `AddEditCustomCliDialog`,
  `AudioPlayer`, `Capabilities`, `ApiKeyInput`, `AttachmentChip`, `hermes-agent`.
  These had drifted across several ad-hoc values; they now share the one hover overlay.

Companion to #106 (sidebar/nav/settings *selected* states, already merged).
Styling-only — no logic, no new dependencies — verified in a local dev build.

### Before / After

Light mode (where the change is most visible) — stock `v1.1.119` vs. this branch:

<img width="1104" height="1596" alt="atomic-contrast-01b" src="https://github.com/user-attachments/assets/22ba1f3b-3d00-44b6-820f-a303e3efa6b9" />

**Model selector — row hover**

<img width="1104" height="1596" alt="atomic-contrast-02" src="https://github.com/user-attachments/assets/37fdff5e-f04d-4a81-856f-ae07959a210a" />

**Hub sort dropdown — selected vs. hover** (were the *same* shade before)

<img width="1104" height="1596" alt="atomic-contrast-04" src="https://github.com/user-attachments/assets/884bf3b2-f5cb-4d8a-b6f6-3d43521cb4a6" />

**Model edit button — hover** (no hover before)

<img width="1104" height="1596" alt="atomic-contrast-05" src="https://github.com/user-attachments/assets/3f1eba8f-9db9-4de1-bdea-d92091b929d6" />

**Search (⌘K) — highlighted result**

<img width="1104" height="1596" alt="atomic-contrast-03" src="https://github.com/user-attachments/assets/b7321821-9ea3-4a1a-a88b-69c29a757cdc" />

**Settings menu — hover vs. selected**

## Fixes Issues

- Closes #107

## Self Checklist

- [ ] Added relevant comments, esp in complex areas — n/a (CSS-class-only change)
- [ ] Updated docs (for bug fixes / features) — n/a
- [ ] Created issues for follow-up changes or refactoring needed — n/a

