### PR TITLE
fix(ui): improve hover contrast for ghost buttons and the settings menu

### DIFF
--- a/web-app/src/components/ui/button.tsx
+++ b/web-app/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary rounded-full text-secondary-foreground hover:bg-secondary/80",
         ghost:
-          "hover:bg-accent rounded-full hover:text-accent-foreground dark:hover:bg-accent/50",
+          "hover:bg-foreground/10 rounded-full hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -168,7 +168,7 @@ const SettingsMenu = () => {
                     matching the sidebar's selected treatment. */}
                 <Link
                   to={menu.route}
-                  className="block px-2 gap-1.5 cursor-pointer hover:dark:bg-secondary/60 hover:bg-secondary py-1 w-full rounded-sm [&.active]:bg-foreground/20"
+                  className="block px-2 gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm [&.active]:bg-foreground/20"
                 >
                   <div className="flex items-center justify-between">
                     <span>{t(menu.title)}</span>
@@ -207,7 +207,7 @@ const SettingsMenu = () => {
                         <div key={provider.provider}>
                           <div
                             className={cn(
-                              'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-foreground',
+                              'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm text-foreground',
                               isActive && 'bg-foreground/20',
                               // hidden for llama.cpp provider for setup remote provider
                               provider.provider === 'llama.cpp' &&
@@ -266,7 +266,7 @@ const SettingsMenu = () => {
                   <div
                     key={provider.provider}
                     className={cn(
-                      'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-foreground',
+                      'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm text-foreground',
                       isRouteActive && 'bg-foreground/20',
                       provider.provider === 'llama.cpp' &&
                         stepSetupRemoteProvider &&
@@ -293,7 +293,7 @@ const SettingsMenu = () => {
               {hiddenProviders.length > 0 && (
                 <>
                   <button
-                    className="flex items-center justify-between px-2 py-1 w-full rounded-sm text-muted-foreground hover:bg-secondary/60"
+                    className="flex items-center justify-between px-2 py-1 w-full rounded-sm text-muted-foreground hover:bg-foreground/10"
                     onClick={() => setExpandedProviders(!expandedProviders)}
                   >
                     <span className="text-sm">
@@ -320,7 +320,7 @@ const SettingsMenu = () => {
                         <div
                           key={provider.provider}
                           className={cn(
-                            'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-secondary/60 py-1 w-full rounded-sm text-muted-foreground',
+                            'flex px-2 items-center gap-1.5 cursor-pointer hover:bg-foreground/10 py-1 w-full rounded-sm text-muted-foreground',
                             isRouteActive && 'bg-foreground/20'
                           )}
                           onClick={() =>


### PR DESCRIPTION
## Describe Your Changes

Follow-on contrast polish to #106 / #140 (which addressed *selected* states). Those
PRs left the **hover** states using absolute `bg-accent` / `bg-secondary` overlays,
which collapse against light backgrounds (both tokens are ≈`0.97` in light, nearly
identical to the surfaces they sit on) — so hover was barely visible, especially in
light mode.

Two fixes, both switching hover to a **background-relative** `bg-foreground/10`
overlay so it's legible on any surface in both themes, and stays a step below the
selected state's `bg-foreground/20` (hover < selected):

- **Ghost buttons** (`components/ui/button.tsx`) — the `ghost` variant's
  `hover:bg-accent` was the faint hover on every ghost button (icon toolbars like
  the message copy/edit/delete/regenerate actions, header icons, menus, …). This is
  a shared design-system change — it affects all `variant="ghost"` buttons app-wide
  (~80 usages). `outline` is intentionally left as-is (it has a border).
- **Settings menu** (`SettingsMenu.tsx`) — the category links used `hover:bg-secondary`
  while the model-provider rows used `hover:bg-secondary/60`, so they didn't match
  and both were faint in light. Unified to the same `hover:bg-foreground/10`.

Styling-only change (no logic, no new dependencies), verified in a local dev build.

### Before / After

<!-- Drag before/after captures (light mode hover) here. -->

## Fixes Issues

_No linked issue — UX/accessibility polish (follow-on to the #107 contrast work)._

## Self Checklist

- [ ] Added relevant comments, esp in complex areas — n/a (CSS-class-only change)
- [ ] Updated docs (for bug fixes / features) — n/a
- [ ] Created issues for follow-up changes or refactoring needed — n/a
