### PR TITLE
fix(sidebar): add hover animation to Integrations nav item

### DIFF
--- a/web-app/src/components/animated-icon/plug.tsx
+++ b/web-app/src/components/animated-icon/plug.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface PlugIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PlugIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+// The two prongs redraw on hover, reading as a quick "reconnect" pulse.
+const PRONG_VARIANTS: Variants = {
+  normal: { pathLength: 1, opacity: 1 },
+  animate: (custom: number) => ({
+    pathLength: [0, 1],
+    opacity: [0, 1],
+    transition: {
+      duration: 0.4,
+      ease: "easeInOut",
+      delay: custom * 0.1,
+      opacity: { delay: custom * 0.1 },
+    },
+  }),
+};
+
+const PlugIcon = forwardRef<PlugIconHandle, PlugIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M12 22v-5" />
+          <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
+          <motion.path
+            animate={controls}
+            custom={0}
+            d="M9 8V2"
+            initial="normal"
+            variants={PRONG_VARIANTS}
+          />
+          <motion.path
+            animate={controls}
+            custom={1}
+            d="M15 8V2"
+            initial="normal"
+            variants={PRONG_VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+PlugIcon.displayName = "PlugIcon";
+
+export { PlugIcon };

--- a/web-app/src/components/left-sidebar/NavMain.tsx
+++ b/web-app/src/components/left-sidebar/NavMain.tsx
@@ -1,4 +1,4 @@
-import { LucideIcon, Plug } from 'lucide-react'
+import { LucideIcon } from 'lucide-react'
 import { route } from '@/constants/routes'
 
 import {
@@ -30,6 +30,7 @@ import {
 } from '@/components/animated-icon/settings'
 import { BlocksIcon, type BlocksIconHandle } from '../animated-icon/blocks'
 import { BotIcon, type BotIconHandle } from '@/components/animated-icon/bot'
+import { PlugIcon, type PlugIconHandle } from '@/components/animated-icon/plug'
 import AddProjectDialog from '@/containers/dialogs/AddProjectDialog'
 import { SearchDialog } from '@/containers/dialogs/SearchDialog'
 import { useThreadManagement } from '@/hooks/useThreadManagement'
@@ -47,6 +48,7 @@ type AnimatedIconHandle =
   | SettingsIconHandle
   | BlocksIconHandle
   | BotIconHandle
+  | PlugIconHandle
 
 type NavMainItem = {
   title: string
@@ -143,7 +145,7 @@ const getNavMainItems = (
   {
     title: 'common:launch',
     url: route.launch.index,
-    icon: Plug,
+    animatedIcon: PlugIcon,
     badge: <NewBadge />,
   },
   {


### PR DESCRIPTION
## Problem

Every animated item in the left sidebar (New Chat, New Projects, Models, Settings, Search…) uses a custom `animated-icon` component. That component is what wires up `onMouseEnter` / `onMouseLeave` on the menu button to start/stop the icon animation on hover.

**Integrations** (`common:launch`) was the only nav item still using a static Lucide `Plug` icon via the `icon` field. Because it went through the non-animated render branch, it had **no hover handlers attached at all**, so the icon never animated on hover — inconsistent with the rest of the menu.

## Fix

- Add `web-app/src/components/animated-icon/plug.tsx` — an animated plug icon following the exact same convention as the existing animated icons (`forwardRef` + `useAnimation` + `useImperativeHandle` exposing `startAnimation` / `stopAnimation`). On hover, the two prongs redraw (`pathLength` 0→1), reading as a quick "reconnect" pulse.
- In `web-app/src/components/left-sidebar/NavMain.tsx`, switch the Integrations item from `icon: Plug` to `animatedIcon: PlugIcon` (added the import, added `PlugIconHandle` to the `AnimatedIconHandle` union, removed the now-unused `Plug` import).

No behavioral change other than the hover animation — the item keeps its `url`, active-state highlight, and the "NEW" badge.

## Verification

- Ran the web app (`yarn dev:web`) and confirmed the Integrations icon now animates on hover, matching the other items.
- Confirmed via the rendered DOM that the Integrations menu button now carries `onMouseEnter` / `onMouseLeave` handlers — identical to Models / Settings / New Chat — whereas before it had none.
- `NavMain.test.tsx` — 3/3 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
