### PR TITLE
feat: speculative decoding acceptance rate in message footer

### DIFF
--- a/web-app/src/containers/TokenSpeedIndicator.tsx
+++ b/web-app/src/containers/TokenSpeedIndicator.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { useAppState } from '@/hooks/useAppState'
 import { toNumber } from '@/utils/number'
-import { Gauge } from 'lucide-react'
+import { Gauge, WholeWord } from 'lucide-react'
 
 interface TokenUsage {
   inputTokens?: number
@@ -13,6 +13,9 @@ interface TokenSpeed {
   tokenSpeed: number
   tokenCount?: number
   durationMs?: number
+  // Speculative decoding stats (llama.cpp draft model: n_drafted / n_accepted).
+  draftTokensTotal?: number
+  draftTokensAccepted?: number
 }
 
 interface TokenSpeedIndicatorProps {
@@ -64,16 +67,27 @@ export const TokenSpeedIndicator = memo(
 
     if (!shouldShow) return
 
+    // Speculative-decoding acceptance rate = accepted / total drafted tokens.
+    const spec = metadata?.tokenSpeed as TokenSpeed | undefined
+    const draftTotal = spec?.draftTokensTotal ?? 0
+    const draftAccepted = spec?.draftTokensAccepted ?? 0
+    const acceptanceRate =
+      draftTotal > 0 ? (draftAccepted / draftTotal) * 100 : null
+
     return (
       <div className="flex items-center gap-2 text-muted-foreground text-xs">
         <div className="flex items-center gap-1">
           <Gauge size={16} />
-          <span>{displaySpeed} tokens/sec</span>
+          <span>{displaySpeed} tok/sec</span>
         </div>
         {displayTokenCount > 0 && (
-          <span className="text-muted-foreground">
-            ({displayTokenCount} tokens)
-          </span>
+          <div className="flex items-center gap-1">
+            <WholeWord size={16} />
+            <span>{displayTokenCount} tokens</span>
+          </div>
+        )}
+        {acceptanceRate !== null && (
+          <span>{acceptanceRate.toFixed(1)}% draft tokens accepted</span>
         )}
       </div>
     )

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -852,6 +852,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     })
 
     let tokensPerSecond = 0
+    let draftTokensTotal: number | null = null
+    let draftTokensAccepted: number | null = null
 
     const uiStream = result.toUIMessageStream({
       messageMetadata: ({ part }) => {
@@ -866,9 +868,12 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
         }
 
         if (part.type === 'finish-step') {
-          tokensPerSecond =
-            (part.providerMetadata?.providerMetadata
-              ?.tokensPerSecond as number) || 0
+          const pm = part.providerMetadata?.providerMetadata as
+            | Record<string, unknown>
+            | undefined
+          tokensPerSecond = (pm?.tokensPerSecond as number) || 0
+          draftTokensTotal = (pm?.draftTokensTotal as number) ?? null
+          draftTokensAccepted = (pm?.draftTokensAccepted as number) ?? null
         }
 
         // Add usage and token speed to metadata on finish
@@ -917,6 +922,12 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
               tokenSpeed: Math.round(tokenSpeed * 10) / 10, // Round to 1 decimal
               tokenCount: outputTokens,
               durationMs,
+              ...(draftTokensTotal != null && draftTokensTotal > 0
+                ? {
+                    draftTokensTotal,
+                    draftTokensAccepted: draftTokensAccepted ?? 0,
+                  }
+                : {}),
             },
           }
         }

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -78,6 +78,10 @@ interface LlamaCppTimings {
   predicted_n?: number
   predicted_per_second?: number
   prompt_per_second?: number
+  // Speculative decoding (draft model / MTP): total drafted and accepted
+  // tokens, emitted by llama.cpp when a draft mechanism is active.
+  draft_n?: number
+  draft_n_accepted?: number
 }
 
 /**
@@ -104,6 +108,8 @@ interface NormalizedMetrics {
   completionTokens: number | null
   tokensPerSecond: number | null
   promptPerSecond: number | null
+  draftTokensTotal: number | null
+  draftTokensAccepted: number | null
 }
 
 const buildFromUsage = (usage: MlxVlmUsage): NormalizedMetrics => ({
@@ -111,6 +117,8 @@ const buildFromUsage = (usage: MlxVlmUsage): NormalizedMetrics => ({
   completionTokens: usage.completion_tokens ?? null,
   tokensPerSecond: usage.generation_tps ?? null,
   promptPerSecond: usage.prompt_tps ?? null,
+  draftTokensTotal: null,
+  draftTokensAccepted: null,
 })
 
 const buildFromTimings = (timings: LlamaCppTimings): NormalizedMetrics => ({
@@ -118,6 +126,8 @@ const buildFromTimings = (timings: LlamaCppTimings): NormalizedMetrics => ({
   completionTokens: timings.predicted_n ?? null,
   tokensPerSecond: timings.predicted_per_second ?? null,
   promptPerSecond: timings.prompt_per_second ?? null,
+  draftTokensTotal: timings.draft_n ?? null,
+  draftTokensAccepted: timings.draft_n_accepted ?? null,
 })
 
 const hasAnyMetric = (m: NormalizedMetrics): boolean =>
@@ -162,6 +172,11 @@ const mergeMetrics = (
     completionTokens: pickCount(u?.completionTokens, t?.completionTokens),
     tokensPerSecond: pickRate(u?.tokensPerSecond, t?.tokensPerSecond),
     promptPerSecond: pickRate(u?.promptPerSecond, t?.promptPerSecond),
+    draftTokensTotal: pickCount(u?.draftTokensTotal, t?.draftTokensTotal),
+    draftTokensAccepted: pickCount(
+      u?.draftTokensAccepted,
+      t?.draftTokensAccepted
+    ),
   }
   return hasAnyMetric(merged) ? merged : null
 }


### PR DESCRIPTION
## What

Adds an LM Studio-style acceptance-rate readout to the assistant message footer when speculative decoding (MTP / draft model) is active:

`⌾ 96 tok/sec · ab 214 tokens · 82.0% draft tokens accepted`

- `tokens/sec` label shortened to `tok/sec`, token count gets the `WholeWord` lucide icon (parens dropped) — matches the LM Studio stats row reference
- new muted-text stat `X.X% draft tokens accepted`, rendered only when draft stats are present in metadata (non-speculative runs are unaffected)

## How

- `TokenSpeedIndicator.tsx`: reads optional `draftTokensTotal` / `draftTokensAccepted` from `metadata.tokenSpeed`, renders acceptance = accepted/total
- `model-factory.ts`: normalizes `draft_n` / `draft_n_accepted` from llama.cpp `timings` (emitted when `--spec-type draft-mtp` or a draft model is active)
- `custom-chat-transport.ts`: carries the two fields through `finish-step` provider metadata into persisted `metadata.tokenSpeed`

## Testing

- Branch is based on the v1.1.150 release commit; `tsc` clean
- Verified in a local `yarn dev` build: footer renders `tok/sec` + token icon on real generations (Qwen3.5-4B-MTP, macos-arm64 b9937)
- Note: toggling MTP in settings does not restart an already-loaded model, so the model must be (re)loaded after enabling MTP for llama.cpp to emit draft timings — worth a follow-up (auto-reload on toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)