### PR TITLE
fix: linux dbus notifications

### DIFF
--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -342,7 +342,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -354,7 +354,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -366,7 +366,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fdownload-extension%40workspace%3Adownload-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Fdownload-extension%40workspace%3Adownload-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Fdownload-extension%40workspace%3Adownload-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -378,7 +378,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Ffoundation-models-extension%40workspace%3Afoundation-models-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Ffoundation-models-extension%40workspace%3Afoundation-models-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Ffoundation-models-extension%40workspace%3Afoundation-models-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -390,7 +390,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fllamacpp-extension%40workspace%3Allamacpp-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Fllamacpp-extension%40workspace%3Allamacpp-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Fllamacpp-extension%40workspace%3Allamacpp-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -402,7 +402,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fllamacpp-upstream-extension%40workspace%3Allamacpp-upstream-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Fllamacpp-upstream-extension%40workspace%3Allamacpp-upstream-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Fllamacpp-upstream-extension%40workspace%3Allamacpp-upstream-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -414,7 +414,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fmlx-extension%40workspace%3Amlx-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Fmlx-extension%40workspace%3Amlx-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Fmlx-extension%40workspace%3Amlx-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -426,7 +426,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Frag-extension%40workspace%3Arag-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Frag-extension%40workspace%3Arag-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Frag-extension%40workspace%3Arag-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
@@ -438,7 +438,7 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fvector-db-extension%40workspace%3Avector-db-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=51bb01&locator=%40janhq%2Fvector-db-extension%40workspace%3Avector-db-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=41692d&locator=%40janhq%2Fvector-db-extension%40workspace%3Avector-db-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "libloading 0.8.9",
  "log",
  "nix",
+ "notify-rust",
  "once_cell",
  "png 0.18.1",
  "rand 0.8.5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -152,6 +152,7 @@ libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = { version = "5", default-features = false, features = ["tokio"] }
+notify-rust = "4"
 
 [target.'cfg(windows)'.dependencies]
 libc = "0.2.172"

--- a/src-tauri/src/core/system/commands.rs
+++ b/src-tauri/src/core/system/commands.rs
@@ -111,7 +111,10 @@ fn write_env_to_shell(env_file_path: &str, env_vars: &[(String, String)]) -> Res
 }
 
 #[tauri::command]
-pub fn factory_reset<R: Runtime>(app_handle: tauri::AppHandle<R>, state: State<'_, AppState>) {
+pub async fn factory_reset<R: Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
     // close window (not available on mobile platforms)
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     {
@@ -125,77 +128,74 @@ pub fn factory_reset<R: Runtime>(app_handle: tauri::AppHandle<R>, state: State<'
     let data_folder = get_jan_data_folder_path(app_handle.clone());
     log::info!("Factory reset, removing data folder: {data_folder:?}");
 
-    tauri::async_runtime::block_on(async {
-        let _ =
-            stop_mcp_servers_with_context(&app_handle, &state, ShutdownContext::FactoryReset).await;
+    let _ = stop_mcp_servers_with_context(&app_handle, &state, ShutdownContext::FactoryReset).await;
 
-        {
-            let mut active_servers = state.mcp_active_servers.lock().await;
-            active_servers.clear();
+    {
+        let mut active_servers = state.mcp_active_servers.lock().await;
+        active_servers.clear();
+    }
+
+    use crate::core::mcp::lockfile::cleanup_own_locks;
+    if let Err(e) = cleanup_own_locks(&app_handle) {
+        log::warn!("Failed to cleanup lock files: {}", e);
+    }
+    // Clean up both llama.cpp providers' process maps.
+    let _ = cleanup_llama_processes(app_handle.clone()).await;
+    let _ = tauri_plugin_llamacpp_upstream::cleanup_llama_processes(app_handle.clone()).await;
+
+    // Windows needs time to release file handles after TerminateProcess
+    #[cfg(windows)]
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    if data_folder.exists() {
+        if !is_safe_to_delete(&data_folder) {
+            log::error!(
+                "Refusing factory reset: path is too close to filesystem root: {}",
+                data_folder.display()
+            );
+            return Ok(());
         }
 
-        use crate::core::mcp::lockfile::cleanup_own_locks;
-        if let Err(e) = cleanup_own_locks(&app_handle) {
-            log::warn!("Failed to cleanup lock files: {}", e);
-        }
-        // Clean up both llama.cpp providers' process maps.
-        let _ = cleanup_llama_processes(app_handle.clone()).await;
-        let _ = tauri_plugin_llamacpp_upstream::cleanup_llama_processes(app_handle.clone()).await;
-
-        // Windows needs time to release file handles after TerminateProcess
-        #[cfg(windows)]
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-        if data_folder.exists() {
-            if !is_safe_to_delete(&data_folder) {
-                log::error!(
-                    "Refusing factory reset: path is too close to filesystem root: {}",
-                    data_folder.display()
-                );
-                return;
+        // Preserve downloaded llamacpp backends across factory reset so the user
+        // doesn't have to re-download CUDA/Vulkan binaries (can be hundreds of MB).
+        let backends_dir = data_folder.join("llamacpp").join("backends");
+        let temp_backends = std::env::temp_dir().join("atomic-chat-backends-preserve");
+        let backends_preserved = if backends_dir.is_dir() {
+            if temp_backends.exists() {
+                let _ = fs::remove_dir_all(&temp_backends);
             }
-
-            // Preserve downloaded llamacpp backends across factory reset so the user
-            // doesn't have to re-download CUDA/Vulkan binaries (can be hundreds of MB).
-            let backends_dir = data_folder.join("llamacpp").join("backends");
-            let temp_backends = std::env::temp_dir().join("atomic-chat-backends-preserve");
-            let backends_preserved = if backends_dir.is_dir() {
-                if temp_backends.exists() {
-                    let _ = fs::remove_dir_all(&temp_backends);
+            match fs::rename(&backends_dir, &temp_backends) {
+                Ok(()) => {
+                    log::info!("Preserved llamacpp backends to temp dir");
+                    true
                 }
-                match fs::rename(&backends_dir, &temp_backends) {
-                    Ok(()) => {
-                        log::info!("Preserved llamacpp backends to temp dir");
-                        true
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to preserve llamacpp backends: {e}");
-                        false
-                    }
-                }
-            } else {
-                false
-            };
-
-            remove_jan_data_contents(&data_folder);
-
-            if backends_preserved {
-                let llamacpp_dir = data_folder.join("llamacpp");
-                let _ = fs::create_dir_all(&llamacpp_dir);
-                match fs::rename(&temp_backends, &backends_dir) {
-                    Ok(()) => log::info!("Restored llamacpp backends after factory reset"),
-                    Err(e) => log::warn!("Failed to restore llamacpp backends: {e}"),
+                Err(e) => {
+                    log::warn!("Failed to preserve llamacpp backends: {e}");
+                    false
                 }
             }
+        } else {
+            false
+        };
+
+        remove_jan_data_contents(&data_folder);
+
+        if backends_preserved {
+            let llamacpp_dir = data_folder.join("llamacpp");
+            let _ = fs::create_dir_all(&llamacpp_dir);
+            match fs::rename(&temp_backends, &backends_dir) {
+                Ok(()) => log::info!("Restored llamacpp backends after factory reset"),
+                Err(e) => log::warn!("Failed to restore llamacpp backends: {e}"),
+            }
         }
+    }
 
-        // Reset the configuration
-        let mut default_config = AppConfiguration::default();
-        default_config.data_folder = default_data_folder_path(app_handle.clone());
-        let _ = update_app_configuration(app_handle.clone(), default_config);
+    // Reset the configuration
+    let mut default_config = AppConfiguration::default();
+    default_config.data_folder = default_data_folder_path(app_handle.clone());
+    let _ = update_app_configuration(app_handle.clone(), default_config);
 
-        app_handle.restart();
-    });
+    app_handle.restart()
 }
 
 #[tauri::command]
@@ -242,6 +242,50 @@ pub fn open_file_explorer(path: String) {
             .arg(path)
             .status()
             .expect("Failed to open file explorer");
+    }
+}
+
+/// Deliver a desktop notification from the blocking pool.
+///
+/// On Linux, do not use the notification plugin: its builder `show()` is
+/// fire-and-forget — it re-spawns the blocking `notify_rust` delivery onto a
+/// tokio runtime worker (`tauri::async_runtime::spawn`). There, delivery goes
+/// over D-Bus via `zbus`, whose `tokio`-feature blocking wrapper calls
+/// `Runtime::block_on` — that panics on a runtime worker ("Cannot start a
+/// runtime from within a runtime"), the detached task dies, and the
+/// notification is silently dropped while the command still returns Ok.
+/// Calling `notify_rust` directly from `spawn_blocking` keeps the zbus
+/// `block_on` on a blocking-pool thread, where it is allowed.
+#[tauri::command]
+pub async fn show_desktop_notification<R: Runtime>(
+    app: AppHandle<R>,
+    title: String,
+    body: String,
+) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        let _ = app;
+        tauri::async_runtime::spawn_blocking(move || {
+            notify_rust::Notification::new()
+                .summary(&title)
+                .body(&body)
+                .auto_icon()
+                .show()
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| format!("Notification task failed: {e}"))?
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        use tauri_plugin_notification::NotificationExt;
+        app.notification()
+            .builder()
+            .title(title)
+            .body(body)
+            .show()
+            .map_err(|e| e.to_string())
     }
 }
 
@@ -3989,5 +4033,42 @@ pub fn migrate_macos_autostart_launchagent<R: Runtime>(
     {
         let _ = &app;
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the SIGABRT after MCP tool-call replies: delivering
+    /// a desktop notification must be safe from a tokio runtime worker thread.
+    /// The plugin's own `notify` command called blocking `show()` (zbus
+    /// `Runtime::block_on` on Linux) directly on a worker and aborted with
+    /// "Cannot start a runtime from within a runtime".
+    #[test]
+    fn show_desktop_notification_is_safe_on_runtime_worker() {
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_notification::init())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("failed to build mock app");
+        let handle = app.handle().clone();
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("failed to build runtime");
+
+        rt.block_on(async move {
+            // Run on a worker thread (not the test thread driving block_on) to
+            // mirror how Tauri executes async commands.
+            tokio::spawn(async move {
+                // Delivery may fail (no notification daemon in CI); the test
+                // only asserts the call does not panic inside the runtime.
+                let _ = show_desktop_notification(handle, "test".into(), "test".into()).await;
+            })
+            .await
+            .expect("notification task panicked");
+        });
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,7 @@ pub fn run() {
         core::system::commands::open_file_explorer,
         core::system::commands::factory_reset,
         core::system::commands::read_logs,
+        core::system::commands::show_desktop_notification,
         core::system::commands::get_installer_type,
         core::system::commands::is_library_available,
         core::system::commands::launch_claude_code_with_config,
@@ -252,6 +253,7 @@ pub fn run() {
         core::system::commands::open_file_explorer,
         core::system::commands::factory_reset,
         core::system::commands::read_logs,
+        core::system::commands::show_desktop_notification,
         core::system::commands::get_installer_type,
         core::system::commands::is_library_available,
         core::system::commands::launch_claude_code_with_config,
@@ -399,6 +401,8 @@ pub fn run() {
                 let backends_dir = get_jan_data_folder_path(app.handle().clone())
                     .join("llamacpp-upstream")
                     .join("backends");
+                // block_on is safe here: the setup closure runs on the main
+                // thread, which is never a tokio runtime worker.
                 match tauri::async_runtime::block_on(install_bundled_backend(
                     app.handle().clone(),
                     backends_dir.to_string_lossy().to_string(),
@@ -523,7 +527,10 @@ pub fn run() {
 
             let state = app_handle.state::<AppState>();
 
-            // Check if cleanup already ran
+            // Check if cleanup already ran.
+            // block_on is safe here: RunEvent callbacks run on the main
+            // thread, which is never a tokio runtime worker (block_in_place
+            // is a pass-through outside a runtime).
             let cleanup_already_running = tokio::task::block_in_place(|| {
                 tauri::async_runtime::block_on(async {
                     let handle = state.background_cleanup_handle.lock().await;

--- a/web-app/src/lib/notifications.ts
+++ b/web-app/src/lib/notifications.ts
@@ -1,7 +1,7 @@
+import { invoke } from '@tauri-apps/api/core'
 import {
   isPermissionGranted,
   requestPermission,
-  sendNotification,
 } from '@tauri-apps/plugin-notification'
 
 const LOG_PREFIX = '[notifications]'
@@ -48,9 +48,12 @@ export async function notifyThreadCompleted(
       console.warn(`${LOG_PREFIX} skipped: OS permission not granted`)
       return
     }
-    console.info(`${LOG_PREFIX} sendNotification →`, { title, body })
-    sendNotification({ title, body })
+    console.info(`${LOG_PREFIX} show_desktop_notification →`, { title, body })
+    // Deliberately not the plugin's sendNotification: its async `notify`
+    // command runs blocking D-Bus delivery on a tokio worker and aborts the
+    // app on Linux (nested-runtime panic). Our command uses spawn_blocking.
+    await invoke('show_desktop_notification', { title, body })
   } catch (error) {
-    console.error(`${LOG_PREFIX} sendNotification failed`, error)
+    console.error(`${LOG_PREFIX} show_desktop_notification failed`, error)
   }
 }


### PR DESCRIPTION
## Describe Your Changes

Deliver Linux desktop notifications off the tokio runtime

#### Issue

On Linux, desktop notifications either crash the atomic chat app, or were silently dropped. It's bad anyway.

Root cause it tauri-plugin-notification's builder. `show()` is fire-and-forget. It re-spawns the blocking `notify-rust` delivery onto a tokio runtime worker via `tauri::async_runtime::spawn`. There, delivery goes over D-bus through `zbus`, whose tokio feature `block_on` calls `Runtime::block_on` on a private static runtime => which PANICS with not being able to start a runtime.

Depending on where the panic lands it either aborts the process or kills a detached task, dropping the notification while still reporting success to the frontend.

#### Fix

- New `show_desktop_notification` command: on Linux it calls `notify-rust` directly from `spawn_blocking` - zbus's `block_on` is allowed on blocking-pool threads (they don't set tokio's runtime-entered flag). Other platforms keep the plugin path. Delivery errors now propagate to the frontend instead of vanishing in a detached task.
- Frontend (`web-app/src/lib/notifications.ts`) invokes the new command instead of the plugin's `sendNotification`.
- `factory_reset` made properly async instead of wrapping its body in `block_on` (same nested-runtime hazard).
- `notify-rust = "4"` added as a direct Linux dependency (was already in the tree transitively via the notification plugin).
- Regression test asserting notification delivery is safe from a tokio runtime worker.
- Refreshed `extensions/yarn.lock` core package.tgz checksums (local core rebuild).

## Fixes issues

- Closes [ATO-289](https://linear.app/atomicchat/issue/ATO-289/app-crashes-with-sigabrt-tokio-runtime-within-runtime-panic-after)