### PR TITLE
fix(tools): show all web search results, not just the first

### DIFF
--- a/web-app/src/components/ai-elements/tools/renderers/web-search-tool-renderer.tsx
+++ b/web-app/src/components/ai-elements/tools/renderers/web-search-tool-renderer.tsx
@@ -28,8 +28,9 @@ export function WebSearchToolRenderer({
         </div>
       )}
 
-      {results.length > 0 &&
-        results.slice(0, 4).map((result, index) => (
+      {results.length > 0 && (
+        <div className="max-h-80 space-y-3 overflow-y-auto pr-1">
+          {results.map((result, index) => (
           <div
             key={`${result.url ?? result.title}-${index}`}
             className="rounded-lg border border-border/60 bg-background/30 p-3"
@@ -54,7 +55,9 @@ export function WebSearchToolRenderer({
               </div>
             </div>
           </div>
-        ))}
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/web-app/src/lib/tools/presenters/__tests__/web-search-exa.test.ts
+++ b/web-app/src/lib/tools/presenters/__tests__/web-search-exa.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { presentWebSearchExa } from '../web-search-exa'
+
+// Exa returns every result inside a single output text item, with individual
+// results separated by a `---` horizontal rule.
+const makeEntry = (n: number) =>
+  [
+    `Title: Result ${n}`,
+    `URL: https://example.com/${n}`,
+    `Published: 2024-01-0${n}`,
+    `Author: Author ${n}`,
+    'Highlights:',
+    `highlight ${n}a`,
+    `highlight ${n}b`,
+  ].join('\n')
+
+const combinedBlock = (count: number) =>
+  Array.from({ length: count }, (_, i) => makeEntry(i + 1)).join('\n\n---\n\n')
+
+describe('presentWebSearchExa', () => {
+  it('renders every result when Exa packs them into one text block', () => {
+    const presentation = presentWebSearchExa({
+      input: { query: 'cafe photos' },
+      output: [{ text: combinedBlock(5) }],
+    })
+
+    expect(presentation.kind).toBe('web_search_exa')
+    expect(presentation.results).toHaveLength(5)
+    expect(presentation.subtitle).toBe('5 results')
+    expect(presentation.results.map((r) => r.url)).toEqual([
+      'https://example.com/1',
+      'https://example.com/2',
+      'https://example.com/3',
+      'https://example.com/4',
+      'https://example.com/5',
+    ])
+    expect(presentation.results[0].title).toBe('Result 1')
+    expect(presentation.results[0].domain).toBe('example.com')
+    expect(presentation.results[0].highlights).toEqual([
+      'highlight 1a',
+      'highlight 1b',
+    ])
+  })
+
+  it('handles a single result with no separator', () => {
+    const presentation = presentWebSearchExa({
+      input: { query: 'q' },
+      output: [{ text: makeEntry(1) }],
+    })
+
+    expect(presentation.results).toHaveLength(1)
+    expect(presentation.subtitle).toBe('1 result')
+    expect(presentation.results[0].title).toBe('Result 1')
+  })
+
+  it('still handles one result per output item (array shape)', () => {
+    const presentation = presentWebSearchExa({
+      input: { query: 'q' },
+      output: [{ text: makeEntry(1) }, { text: makeEntry(2) }],
+    })
+
+    expect(presentation.results).toHaveLength(2)
+    expect(presentation.subtitle).toBe('2 results')
+  })
+
+  it('returns no results for empty output', () => {
+    const presentation = presentWebSearchExa({ input: { query: 'q' }, output: [] })
+    expect(presentation.results).toHaveLength(0)
+    expect(presentation.subtitle).toBeUndefined()
+  })
+})

--- a/web-app/src/lib/tools/presenters/web-search-exa.ts
+++ b/web-app/src/lib/tools/presenters/web-search-exa.ts
@@ -9,6 +9,17 @@ type SearchResultCard = {
   highlights: string[]
 }
 
+// Exa concatenates multiple results into a single text block, separated by a
+// horizontal rule (`---`). Split them so each result becomes its own card.
+// Falls back to the whole string when there is no separator (a single result,
+// or one result per output item), so both output shapes are handled.
+function splitExaResults(text: string): string[] {
+  return text
+    .split(/\n\s*-{3,}\s*\n/)
+    .map((chunk) => chunk.trim())
+    .filter((chunk) => chunk.includes('Title:'))
+}
+
 function parseExaTextEntry(text: string): SearchResultCard | undefined {
   const lines = text.split('\n').map((l) => l.trim())
 
@@ -70,7 +81,8 @@ export function presentWebSearchExa(args: {
       (item): item is { text?: string } =>
         !!item && typeof item === 'object' && 'text' in item
     )
-    .map((item) => parseExaTextEntry(item.text ?? ''))
+    .flatMap((item) => splitExaResults(item.text ?? ''))
+    .map((entry) => parseExaTextEntry(entry))
     .filter(isSearchResultCard)
 
   return {


### PR DESCRIPTION
## Describe Your Changes

The web search tool only rendered the **first** result even when the search
returned several (the results list showed one card and the subtitle read
"1 result"). There were actually two stacked limits.

**1. Presenter dropped all but the first result.** Exa's `web_search_exa` packs
every result into a single `output[0].text` block, with results separated by a
`---` horizontal rule. The presenter rendered one card per output *item*, and
`parseExaTextEntry` only reads the first `Title:`/`URL:` in each item, so
everything after the first result was dropped and the count was wrong. This
splits each output item's text on the `---` separator before parsing, so every
result becomes its own card. It falls back to the whole string when there is no
separator, so a single result (or the one-result-per-item shape) still works.

I checked several saved searches to confirm the separator is stable: the number
of `---` rules is consistently one less than the number of results, so the split
lines up exactly.

**2. Renderer capped the display to four.** Even with the parser fixed, the
renderer only drew `results.slice(0, 4)`, so a 5 or 10 result search still
showed four cards. It now renders every result inside a fixed-height
(`max-h-80`) `overflow-y-auto` container, so the block stays about four cards
tall and you scroll through the rest rather than getting a wall of cards.

With both fixes, searches that returned 5 and 10 results now show all of them
(scrollable) with an accurate count, instead of 1 then 4.

Added unit tests for the presenter (packed block, single result,
one-result-per-item, empty output). Verified end to end in a local dev build:
live Exa searches now render the full, scrollable result list.

## Fixes Issues

- Closes #171

## New Behavior video:

https://github.com/user-attachments/assets/b95ee366-6ed3-4043-9b58-d6c19af1f405



## Self Checklist

- [x] Added relevant comments, esp in complex areas (noted why the split is needed on the helper)
- [ ] Updated docs (for bug fixes / features): n/a
- [ ] Created issues for follow-up changes or refactoring needed: n/a