### PR TITLE
feat: bundle all upstream Windows DLLs and improve backend preference…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,7 +551,11 @@ jobs:
           if [ ! -f "$DIR/build/bin/llama-server.exe" ] && [ -f "$DIR/llama-server.exe" ]; then
             echo "Relocating flat-extracted binaries into build/bin/..."
             mkdir -p "$DIR/build/bin"
-            mv "$DIR"/*.exe "$DIR/build/bin/" 2>/dev/null || true
+            find "$DIR" -maxdepth 1 -type f ! -name version.txt ! -name backend.txt -exec mv {} "$DIR/build/bin/" \;
+          fi
+          if [ ! -f "$DIR/build/bin/llama-server-impl.dll" ]; then
+            echo "Error: upstream backend is missing build/bin/llama-server-impl.dll"
+            exit 1
           fi
           echo "CPU backend ($BACKEND) downloaded successfully. App will auto-download GPU backend at runtime."
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,46 @@ Append-only. Newest at top. Each entry follows this shape:
 
 ---
 
+### 2026-07-14 — Bundle every upstream Windows DLL, repair incomplete installs, and isolate provider backend preferences (ATO-294)
+- **Context:** GitHub #175 reported `llama-server.exe` failing on relaunch
+ because `llama-server-impl.dll` was absent from
+ `resources/llamacpp-backend-upstream/build/bin`. The ggml-org Windows archive
+ is flat, but the release workflow relocated only `*.exe` into `build/bin`;
+ DLLs stayed at the resource root while `install_bundled_backend` copied only
+ the `build/` tree into the user backend directory. Existing installs were
+ then treated as valid because the upstream plugin checked only the executable
+ and backend version. The TurboQuant and upstream extensions also shared the
+ `llama_cpp_backend_type` localStorage key despite using incompatible clean
+ backend ids (`windows-x64-vulkan` versus `win-vulkan-x64`), so either provider
+ could overwrite the other's preference.
+- **Decision:** Relocate every non-metadata top-level file from the flat
+ upstream archive into `build/bin`, fail the Windows release job unless
+ `llama-server-impl.dll` is present there, and mirror the TurboQuant plugin's
+ recursive bundled-backend completeness check in
+ `tauri-plugin-llamacpp-upstream`. When an installed backend has the expected
+ executable/version but lacks any bundled file, copy the bundled `build/`
+ tree over it in place. Store backend-type preferences under separate Atomic
+ Chat keys for TurboQuant and upstream. On first read, migrate the legacy
+ shared value only when its id shape belongs to that provider; leave the
+ legacy key untouched so both extensions can independently inspect it.
+- **Consequences:** New Windows installers contain the complete upstream
+ runtime, and upgrades repair previously incomplete user backend directories
+ without deleting models, settings, or the whole `llamacpp-upstream` tree.
+ The repair can only restore files present in the new app bundle; users must
+ install a fixed build first. Provider selections no longer overwrite one
+ another or oscillate between incompatible id schemes. Verified by upstream
+ plugin unit tests and provider-preference migration tests; a packaged Windows
+ install/relaunch smoke test remains required.
+- **Owner:** team.
+- **Links:** [ATO-294](https://linear.app/atomicchat/issue/ATO-294),
+ [GitHub #175](https://github.com/AtomicBot-ai/Atomic-Chat/issues/175),
+ [`.github/workflows/release.yml`](.github/workflows/release.yml),
+ [`src-tauri/plugins/tauri-plugin-llamacpp-upstream/src/backend.rs`](src-tauri/plugins/tauri-plugin-llamacpp-upstream/src/backend.rs),
+ [`extensions/llamacpp-extension/src/index.ts`](extensions/llamacpp-extension/src/index.ts),
+ [`extensions/llamacpp-upstream-extension/src/index.ts`](extensions/llamacpp-upstream-extension/src/index.ts).
+
+---
+
 ### 2026-07-14 — Resume interrupted model downloads from verified persisted offsets
 - **Context:** Large GGUF downloads failed permanently when an HTTP body ended
  early, including the `end of file before message length reached` failure in

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -155,6 +155,18 @@ const logger = {
   },
 }
 
+const TURBOQUANT_BACKEND_TYPE_KEY =
+  'atomic_llamacpp_turboquant_backend_type'
+const LEGACY_SHARED_BACKEND_TYPE_KEY = 'llama_cpp_backend_type'
+
+function isTurboquantBackendType(value: string): boolean {
+  return (
+    value.startsWith('windows-x64-') ||
+    value.startsWith('linux-x64-') ||
+    value.startsWith('macos-')
+  )
+}
+
 /**
  * Coerce an unknown model-load error into a human-readable string.
  *
@@ -487,8 +499,26 @@ export default class llamacpp_extension extends AIEngine {
 
   private getStoredBackendType(): string | null {
     try {
-      const val = localStorage.getItem('llama_cpp_backend_type')
-      return val ? stripBom(val) : null
+      const value = localStorage.getItem(TURBOQUANT_BACKEND_TYPE_KEY)
+      if (value) return stripBom(value)
+
+      const legacyValue = localStorage.getItem(LEGACY_SHARED_BACKEND_TYPE_KEY)
+      const normalizedLegacyValue = legacyValue ? stripBom(legacyValue) : null
+      if (
+        normalizedLegacyValue &&
+        isTurboquantBackendType(normalizedLegacyValue)
+      ) {
+        localStorage.setItem(
+          TURBOQUANT_BACKEND_TYPE_KEY,
+          normalizedLegacyValue
+        )
+        logger.info(
+          `Migrated TurboQuant backend preference from legacy shared key: ${normalizedLegacyValue}`
+        )
+        return normalizedLegacyValue
+      }
+
+      return null
     } catch (error) {
       logger.warn('Failed to read backend type from localStorage:', error)
       return null
@@ -497,7 +527,7 @@ export default class llamacpp_extension extends AIEngine {
 
   private setStoredBackendType(backendType: string): void {
     try {
-      localStorage.setItem('llama_cpp_backend_type', backendType)
+      localStorage.setItem(TURBOQUANT_BACKEND_TYPE_KEY, backendType)
       logger.info(`Stored backend type preference: ${backendType}`)
     } catch (error) {
       logger.warn('Failed to store backend type in localStorage:', error)
@@ -506,7 +536,7 @@ export default class llamacpp_extension extends AIEngine {
 
   private clearStoredBackendType(): void {
     try {
-      localStorage.removeItem('llama_cpp_backend_type')
+      localStorage.removeItem(TURBOQUANT_BACKEND_TYPE_KEY)
       logger.info('Cleared stored backend type preference')
     } catch (error) {
       logger.warn('Failed to clear backend type from localStorage:', error)

--- a/extensions/llamacpp-extension/src/test/index.test.ts
+++ b/extensions/llamacpp-extension/src/test/index.test.ts
@@ -6,6 +6,12 @@ import { normalizeLlamacppConfig } from '@janhq/tauri-plugin-llamacpp-api'
 // Mock fetch globally
 global.fetch = vi.fn()
 
+vi.mock('@tauri-apps/plugin-log', () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+
 // Mock backend functions
 vi.mock('../backend', () => ({
   isBackendInstalled: vi.fn(),
@@ -43,6 +49,53 @@ describe('llamacpp_extension', () => {
       expect(extension.provider).toBe('llamacpp')
       expect(extension.providerId).toBe('llamacpp')
       expect(extension.autoUnload).toBe(true)
+    })
+  })
+
+  describe('backend preference storage', () => {
+    it('uses the TurboQuant-specific key', () => {
+      vi.mocked(localStorage.getItem).mockReturnValueOnce(
+        'windows-x64-vulkan'
+      )
+
+      expect(extension['getStoredBackendType']()).toBe('windows-x64-vulkan')
+      expect(localStorage.getItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_turboquant_backend_type'
+      )
+    })
+
+    it('migrates a matching legacy TurboQuant preference', () => {
+      vi.mocked(localStorage.getItem)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce('windows-x64-vulkan')
+
+      expect(extension['getStoredBackendType']()).toBe('windows-x64-vulkan')
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_turboquant_backend_type',
+        'windows-x64-vulkan'
+      )
+    })
+
+    it('does not import an upstream preference from the shared key', () => {
+      vi.mocked(localStorage.getItem)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce('win-vulkan-x64')
+
+      expect(extension['getStoredBackendType']()).toBeNull()
+      expect(localStorage.setItem).not.toHaveBeenCalled()
+    })
+
+    it('writes and clears only the TurboQuant-specific key', () => {
+      extension['setStoredBackendType']('windows-x64-vulkan')
+      extension['clearStoredBackendType']()
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_turboquant_backend_type',
+        'windows-x64-vulkan'
+      )
+      expect(localStorage.removeItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_turboquant_backend_type'
+      )
     })
   })
 

--- a/extensions/llamacpp-upstream-extension/src/index.ts
+++ b/extensions/llamacpp-upstream-extension/src/index.ts
@@ -215,6 +215,18 @@ const logger = {
   },
 }
 
+const UPSTREAM_BACKEND_TYPE_KEY = 'atomic_llamacpp_upstream_backend_type'
+const LEGACY_SHARED_BACKEND_TYPE_KEY = 'llama_cpp_backend_type'
+
+function isUpstreamBackendType(value: string): boolean {
+  return (
+    value.startsWith('win-') ||
+    value.startsWith('linux-cpu-') ||
+    value.startsWith('linux-vulkan-') ||
+    value.startsWith('macos-')
+  )
+}
+
 /**
  * Coerce an unknown model-load error into a human-readable string.
  *
@@ -609,8 +621,26 @@ export default class llamacpp_upstream_extension extends AIEngine {
 
   private getStoredBackendType(): string | null {
     try {
-      const val = localStorage.getItem('llama_cpp_backend_type')
-      return val ? stripBom(val) : null
+      const value = localStorage.getItem(UPSTREAM_BACKEND_TYPE_KEY)
+      if (value) return stripBom(value)
+
+      const legacyValue = localStorage.getItem(LEGACY_SHARED_BACKEND_TYPE_KEY)
+      const normalizedLegacyValue = legacyValue ? stripBom(legacyValue) : null
+      if (
+        normalizedLegacyValue &&
+        isUpstreamBackendType(normalizedLegacyValue)
+      ) {
+        localStorage.setItem(
+          UPSTREAM_BACKEND_TYPE_KEY,
+          normalizedLegacyValue
+        )
+        logger.info(
+          `Migrated upstream backend preference from legacy shared key: ${normalizedLegacyValue}`
+        )
+        return normalizedLegacyValue
+      }
+
+      return null
     } catch (error) {
       logger.warn('Failed to read backend type from localStorage:', error)
       return null
@@ -619,7 +649,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
 
   private setStoredBackendType(backendType: string): void {
     try {
-      localStorage.setItem('llama_cpp_backend_type', backendType)
+      localStorage.setItem(UPSTREAM_BACKEND_TYPE_KEY, backendType)
       logger.info(`Stored backend type preference: ${backendType}`)
     } catch (error) {
       logger.warn('Failed to store backend type in localStorage:', error)
@@ -628,7 +658,7 @@ export default class llamacpp_upstream_extension extends AIEngine {
 
   private clearStoredBackendType(): void {
     try {
-      localStorage.removeItem('llama_cpp_backend_type')
+      localStorage.removeItem(UPSTREAM_BACKEND_TYPE_KEY)
       logger.info('Cleared stored backend type preference')
     } catch (error) {
       logger.warn('Failed to clear backend type from localStorage:', error)

--- a/extensions/llamacpp-upstream-extension/src/test/index.test.ts
+++ b/extensions/llamacpp-upstream-extension/src/test/index.test.ts
@@ -6,6 +6,12 @@ import { normalizeLlamacppConfig } from '@janhq/tauri-plugin-llamacpp-upstream-a
 // Mock fetch globally
 global.fetch = vi.fn()
 
+vi.mock('@tauri-apps/plugin-log', () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+
 // Mock backend functions
 vi.mock('../backend', () => ({
   isBackendInstalled: vi.fn(),
@@ -43,6 +49,51 @@ describe('llamacpp_extension', () => {
       expect(extension.provider).toBe('llamacpp')
       expect(extension.providerId).toBe('llamacpp')
       expect(extension.autoUnload).toBe(true)
+    })
+  })
+
+  describe('backend preference storage', () => {
+    it('uses the upstream-specific key', () => {
+      vi.mocked(localStorage.getItem).mockReturnValueOnce('win-vulkan-x64')
+
+      expect(extension['getStoredBackendType']()).toBe('win-vulkan-x64')
+      expect(localStorage.getItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_upstream_backend_type'
+      )
+    })
+
+    it('migrates a matching legacy upstream preference', () => {
+      vi.mocked(localStorage.getItem)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce('win-vulkan-x64')
+
+      expect(extension['getStoredBackendType']()).toBe('win-vulkan-x64')
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_upstream_backend_type',
+        'win-vulkan-x64'
+      )
+    })
+
+    it('does not import a TurboQuant preference from the shared key', () => {
+      vi.mocked(localStorage.getItem)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce('windows-x64-vulkan')
+
+      expect(extension['getStoredBackendType']()).toBeNull()
+      expect(localStorage.setItem).not.toHaveBeenCalled()
+    })
+
+    it('writes and clears only the upstream-specific key', () => {
+      extension['setStoredBackendType']('win-vulkan-x64')
+      extension['clearStoredBackendType']()
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_upstream_backend_type',
+        'win-vulkan-x64'
+      )
+      expect(localStorage.removeItem).toHaveBeenCalledWith(
+        'atomic_llamacpp_upstream_backend_type'
+      )
     })
   })
 

--- a/src-tauri/plugins/tauri-plugin-llamacpp-upstream/src/backend.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp-upstream/src/backend.rs
@@ -1130,6 +1130,44 @@ fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) -> Result<(), String> {
     Ok(())
 }
 
+fn bundled_backend_is_complete(resource_build: &PathBuf, target_build: &PathBuf) -> bool {
+    let entries = match fs::read_dir(resource_build) {
+        Ok(entries) => entries,
+        Err(_) => return false,
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => return false,
+        };
+        let source = entry.path();
+        let target = target_build.join(entry.file_name());
+
+        if source.is_dir() {
+            if !bundled_backend_is_complete(&source, &target) {
+                return false;
+            }
+        } else if !target.exists() {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn backfill_bundled_backend_if_needed(
+    resource_build: &PathBuf,
+    target_build: &PathBuf,
+) -> Result<bool, String> {
+    if bundled_backend_is_complete(resource_build, target_build) {
+        return Ok(false);
+    }
+
+    copy_dir_recursive(resource_build, target_build)?;
+    Ok(true)
+}
+
 #[tauri::command]
 pub async fn install_bundled_backend<R: Runtime>(
     app: tauri::AppHandle<R>,
@@ -1212,8 +1250,17 @@ pub async fn install_bundled_backend<R: Runtime>(
     }
 
     let target_dir = PathBuf::from(&backends_dir).join(&version).join(&backend);
+    let target_build_dir = target_dir.join("build");
 
     if is_backend_installed(&target_dir) {
+        if backfill_bundled_backend_if_needed(&build_dir, &target_build_dir)? {
+            log::warn!(
+                "[install_bundled_backend] Bundled backend {}/{} is incomplete; backfilled missing files",
+                version,
+                backend
+            );
+        }
+
         if backend_binary_matches_version(&target_dir, &version) {
             log::info!(
                 "[install_bundled_backend] Bundled backend already installed: {}/{}",
@@ -1242,7 +1289,6 @@ pub async fn install_bundled_backend<R: Runtime>(
         version, backend, resource_dir.display()
     );
 
-    let target_build_dir = target_dir.join("build");
     copy_dir_recursive(&build_dir, &target_build_dir)?;
 
     #[cfg(unix)]
@@ -1851,6 +1897,53 @@ mod tests {
             Some(9222)
         );
         assert_eq!(parse_binary_version("unknown version"), None);
+    }
+
+    #[test]
+    fn test_bundled_backend_is_complete() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let resource_build = temp_dir.path().join("resource").join("build");
+        let target_build = temp_dir.path().join("target").join("build");
+
+        fs::create_dir_all(resource_build.join("bin")).unwrap();
+        fs::create_dir_all(target_build.join("bin")).unwrap();
+        File::create(resource_build.join("bin").join("llama-server.exe")).unwrap();
+        File::create(resource_build.join("bin").join("llama-server-impl.dll")).unwrap();
+        File::create(target_build.join("bin").join("llama-server.exe")).unwrap();
+        File::create(target_build.join("bin").join("llama-server-impl.dll")).unwrap();
+
+        assert!(bundled_backend_is_complete(&resource_build, &target_build));
+    }
+
+    #[test]
+    fn test_backfill_restores_missing_bundled_dll() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let resource_build = temp_dir.path().join("resource").join("build");
+        let target_build = temp_dir.path().join("target").join("build");
+
+        fs::create_dir_all(resource_build.join("bin")).unwrap();
+        fs::create_dir_all(target_build.join("bin")).unwrap();
+        File::create(resource_build.join("bin").join("llama-server.exe")).unwrap();
+        File::create(resource_build.join("bin").join("llama-server-impl.dll")).unwrap();
+        File::create(target_build.join("bin").join("llama-server.exe")).unwrap();
+
+        assert!(!bundled_backend_is_complete(&resource_build, &target_build));
+        assert!(backfill_bundled_backend_if_needed(&resource_build, &target_build).unwrap());
+        assert!(target_build.join("bin").join("llama-server-impl.dll").exists());
+        assert!(bundled_backend_is_complete(&resource_build, &target_build));
+        assert!(!backfill_bundled_backend_if_needed(&resource_build, &target_build).unwrap());
+    }
+
+    #[test]
+    fn test_bundled_backend_is_incomplete_when_target_is_missing() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let resource_build = temp_dir.path().join("resource").join("build");
+        let target_build = temp_dir.path().join("target").join("build");
+
+        fs::create_dir_all(resource_build.join("bin")).unwrap();
+        File::create(resource_build.join("bin").join("llama-server.exe")).unwrap();
+
+        assert!(!bundled_backend_is_complete(&resource_build, &target_build));
     }
 
     // --- Filesystem Integration Tests ---


### PR DESCRIPTION
… handling

This commit addresses the issue of incomplete installations by ensuring that all necessary Windows DLLs are included in the release bundle. It relocates DLLs to the appropriate directory and implements a check to prevent releases without the required `llama-server-impl.dll`. Additionally, it separates backend preferences for TurboQuant and upstream extensions to avoid conflicts, migrating legacy preferences as needed. This enhances the installation process and user experience by ensuring complete backend functionality and preventing provider preference overwrites.

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
