### PR TITLE
feat: enhance MLX checkpoint loading and session management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,46 @@ Append-only. Newest at top. Each entry follows this shape:
 
 ---
 
+### 2026-07-14 — Route text-only MLX checkpoints by embodied weights and keep failed loads off the session-map lock (ATO-295)
+- **Context:** Ornith-like MLX checkpoints can retain a VLM wrapper in
+ `config.json` (`vision_config`, image token ids, or a conditional-generation
+ architecture) while shipping only language-model weights. `mlx-vlm` selected
+ the VLM class before inspecting those weights, so strict loading failed on
+ absent vision tensors. Atomic Chat also held the MLX session-map mutex across
+ validation, process spawn, and readiness waits; `/v1/models` uses that map and
+ could therefore block behind a long or failed load. The desktop extension
+ compounded the mismatch by advertising vision from stale `mmproj_path` or
+ processor/config hints without checking the indexed weight names.
+- **Decision:** In `mlx-vlm`, classify a checkpoint before model-class
+ construction using both config and loaded safetensors keys. Route through the
+ existing `mlx_vlm.models.text_only` adapter when a nested text model is
+ declared and no embodied vision/audio/projector weights exist, and pass the
+ nested `text_config.model_type` to `mlx-lm`. Keep the normal VLM path and
+ strict weight loading whenever multimodal weights are present; do not use
+ `strict=False` as recovery. In `tauri-plugin-mlx`, serialize loads with a
+ dedicated `load_operation` mutex and hold `mlx_server_process` only for final
+ insert/remove/read operations. In the MLX extension, derive the live vision
+ capability from `vision_config` plus
+ `model.safetensors.index.json::weight_map` when available, including for
+ already-imported models.
+- **Consequences:** Text-only checkpoints wrapped in VLM metadata load through
+ `mlx-lm`, while genuinely incomplete VLMs still fail diagnostically under
+ strict loading. Failed or slow loads do not create phantom sessions and no
+ longer monopolize the map read by `/v1/models`. Vision reporting is
+ conservative for indexed checkpoints; single-file safetensors remain under
+ the Python loader's authoritative runtime classification because no new
+ desktop parser or IPC was added. Verified by 35 targeted `mlx-vlm` tests,
+ 8 `tauri-plugin-mlx` tests, 7 capability tests, and the MLX extension build.
+- **Owner:** team.
+- **Links:** [ATO-295](https://linear.app/atomicchat/issue/ATO-295),
+ [AtomicBot-ai/mlx-vlm](https://github.com/AtomicBot-ai/mlx-vlm),
+ [`src-tauri/plugins/tauri-plugin-mlx/src/state.rs`](src-tauri/plugins/tauri-plugin-mlx/src/state.rs),
+ [`src-tauri/plugins/tauri-plugin-mlx/src/commands.rs`](src-tauri/plugins/tauri-plugin-mlx/src/commands.rs),
+ [`extensions/mlx-extension/src/visionCapability.ts`](extensions/mlx-extension/src/visionCapability.ts),
+ [`extensions/mlx-extension/src/index.ts`](extensions/mlx-extension/src/index.ts).
+
+---
+
 ### 2026-07-14 — Bundle every upstream Windows DLL, repair incomplete installs, and isolate provider backend preferences (ATO-294)
 - **Context:** GitHub #175 reported `llama-server.exe` failing on relaunch
  because `llama-server-impl.dll` was absent from

--- a/extensions/mlx-extension/src/index.ts
+++ b/extensions/mlx-extension/src/index.ts
@@ -39,6 +39,7 @@ import { readGgufMetadata, ModelConfig } from '@janhq/tauri-plugin-llamacpp-api'
 import { resolveDflashDraft, DraftResolution } from './dflashRegistry'
 import { resolveMtpDraft } from './mtpRegistry'
 import { resolveEagle3Draft } from './eagle3Registry'
+import { classifyMlxVisionCapability } from './visionCapability'
 
 /// The three mutually-exclusive speculative-decoding families surfaced by
 /// the MLX extension. Maps 1:1 onto mlx-vlm's `--draft-kind` choices
@@ -385,7 +386,8 @@ export default class mlx_extension extends AIEngine {
       const modelConfig = await invoke<ModelConfig>('read_yaml', { path })
 
       const capabilities: string[] = []
-      if (modelConfig.mmproj_path) {
+      const resolvedPath = await this.resolveModelPath(modelConfig.model_path)
+      if (resolvedPath && (await this.isVisionSupported(resolvedPath))) {
         capabilities.push('vision')
       }
 
@@ -427,7 +429,6 @@ export default class mlx_extension extends AIEngine {
       }
 
       // Broken-link detection: flag a missing weights file/dir so the UI marks it and auto-start skips it.
-      const resolvedPath = await this.resolveModelPath(modelConfig.model_path)
       const missing = resolvedPath
         ? !(await fs.existsSync(resolvedPath).catch(() => true))
         : false
@@ -1432,13 +1433,15 @@ export default class mlx_extension extends AIEngine {
   }
 
   async isVisionSupported(modelPath: string): Promise<boolean> {
-    // Check if model is a Vision Language Model by examining config.json
-    // modelPath can be a folder path or a file path; resolve to directory
     const stat = await fs.fileStat(modelPath).catch(() => null)
+    const separatorIndex = Math.max(
+      modelPath.lastIndexOf('/'),
+      modelPath.lastIndexOf('\\')
+    )
     const modelDir =
       stat && stat.isDirectory
         ? modelPath
-        : modelPath.substring(0, modelPath.lastIndexOf('/'))
+        : modelPath.substring(0, separatorIndex)
     const configPath = await joinPath([modelDir, 'config.json'])
 
     if (!(await fs.existsSync(configPath))) {
@@ -1450,72 +1453,19 @@ export default class mlx_extension extends AIEngine {
         args: [configPath],
       })
       const config = JSON.parse(configContent)
-
-      // Check architecture for vision models
-      const architectures = config.architectures
-      if (architectures && Array.isArray(architectures)) {
-        const archString = architectures[0]?.toString().toLowerCase() ?? ''
-        // Common VLM architecture suffixes
-        const vlmPatterns = [
-          'vl',
-          'vlm',
-          'vision',
-          'llava',
-          'qwen2vl',
-          'qwen3vl',
-          'idefics',
-          'fuyu',
-          'paligemma',
-          'clip',
-          'siglip',
-        ]
-        if (vlmPatterns.some((pattern) => archString.includes(pattern))) {
-          logger.info(
-            `Vision support detected from config.json: ${architectures[0]}`
-          )
-          return true
-        }
-      }
-
-      // Check for vision-related configuration fields
-      if (config.visual_architectures || config.vision_config) {
-        logger.info(
-          'Vision support detected from visual_architectures/vision_config'
-        )
-        return true
-      }
-
-      // Check for image processor config
-      const imageProcessorPath = await joinPath([
+      const indexPath = await joinPath([
         modelDir,
-        'image_processor_config.json',
+        'model.safetensors.index.json',
       ])
-      if (await fs.existsSync(imageProcessorPath)) {
-        logger.info('Vision support detected from image_processor_config.json')
-        return true
+      let safetensorsIndex: unknown
+      if (await fs.existsSync(indexPath)) {
+        const indexContent = await invoke<string>('read_file_sync', {
+          args: [indexPath],
+        })
+        safetensorsIndex = JSON.parse(indexContent)
       }
 
-      // Check preprocessor config for vision
-      const preprocessorConfigPath = await joinPath([
-        modelDir,
-        'preprocessor_config.json',
-      ])
-      if (await fs.existsSync(preprocessorConfigPath)) {
-        try {
-          const preprocessorConfig = await invoke<string>('read_file_sync', {
-            args: [preprocessorConfigPath],
-          })
-          const pc = JSON.parse(preprocessorConfig)
-          if (pc.do_resize || pc.size || pc.patch_size) {
-            logger.info('Vision support detected from preprocessor_config.json')
-            return true
-          }
-        } catch (e) {
-          // Ignore
-        }
-      }
-
-      return false
+      return classifyMlxVisionCapability(config, safetensorsIndex)
     } catch (e) {
       logger.warn(`Failed to check vision support for ${modelPath}: ${e}`)
       return false

--- a/extensions/mlx-extension/src/visionCapability.test.ts
+++ b/extensions/mlx-extension/src/visionCapability.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyMlxVisionCapability,
+  isMultimodalWeight,
+} from './visionCapability'
+
+describe('classifyMlxVisionCapability', () => {
+  it('rejects VLM-like metadata without vision config', () => {
+    expect(
+      classifyMlxVisionCapability({
+        architectures: ['OrnithForConditionalGeneration'],
+        visual_architectures: ['SiglipVisionModel'],
+        image_token_id: 248056,
+        text_config: { model_type: 'qwen3_5_moe' },
+      })
+    ).toBe(false)
+  })
+
+  it('accepts vision config when no safetensors index is available', () => {
+    expect(
+      classifyMlxVisionCapability({
+        model_type: 'qwen3_5',
+        vision_config: { hidden_size: 1024 },
+      })
+    ).toBe(true)
+  })
+
+  it('rejects wrapper config whose indexed weights are text-only', () => {
+    expect(
+      classifyMlxVisionCapability(
+        {
+          model_type: 'qwen3_5',
+          text_config: { model_type: 'qwen3_5_moe' },
+          vision_config: { hidden_size: 1024 },
+        },
+        {
+          weight_map: {
+            'language_model.model.embed_tokens.weight':
+              'model-00001-of-00002.safetensors',
+          },
+        }
+      )
+    ).toBe(false)
+  })
+
+  it('accepts indexed checkpoints with embodied vision weights', () => {
+    expect(
+      classifyMlxVisionCapability(
+        { vision_config: { hidden_size: 1024 } },
+        {
+          weight_map: {
+            'model.vision_tower.blocks.0.attn.q_proj.weight':
+              'model-00001-of-00002.safetensors',
+          },
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('rejects malformed safetensors indexes conservatively', () => {
+    expect(
+      classifyMlxVisionCapability(
+        { vision_config: { hidden_size: 1024 } },
+        { metadata: {} }
+      )
+    ).toBe(false)
+  })
+})
+
+describe('isMultimodalWeight', () => {
+  it('recognizes projector and visual weight names', () => {
+    expect(isMultimodalWeight('model.mm_projector.0.weight')).toBe(true)
+    expect(isMultimodalWeight('model.visual.blocks.0.weight')).toBe(true)
+  })
+
+  it('does not classify language weights as multimodal', () => {
+    expect(
+      isMultimodalWeight('language_model.model.layers.0.self_attn.q_proj.weight')
+    ).toBe(false)
+  })
+})

--- a/extensions/mlx-extension/src/visionCapability.ts
+++ b/extensions/mlx-extension/src/visionCapability.ts
@@ -1,0 +1,54 @@
+type JsonObject = Record<string, unknown>
+
+const MULTIMODAL_WEIGHT_MARKERS = [
+  'vision_model',
+  'vision_tower',
+  'visual.',
+  'vl_connector',
+  'projector',
+  'image_newline',
+  'image_token',
+  'img_projector',
+  'multi_modal',
+  'multimodal',
+  'perceiver',
+]
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function isMultimodalWeight(name: string): boolean {
+  const normalized = name.toLowerCase()
+  return MULTIMODAL_WEIGHT_MARKERS.some((marker) =>
+    normalized.includes(marker)
+  )
+}
+
+export function classifyMlxVisionCapability(
+  config: unknown,
+  safetensorsIndex?: unknown
+): boolean {
+  if (
+    !isObject(config) ||
+    !isObject(config.vision_config) ||
+    Object.keys(config.vision_config).length === 0
+  ) {
+    return false
+  }
+
+  if (safetensorsIndex === undefined) {
+    return true
+  }
+
+  if (!isObject(safetensorsIndex)) {
+    return false
+  }
+
+  const weightMap = safetensorsIndex.weight_map
+  if (!isObject(weightMap)) {
+    return false
+  }
+
+  return Object.keys(weightMap).some(isMultimodalWeight)
+}

--- a/src-tauri/plugins/tauri-plugin-mlx/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-mlx/src/commands.rs
@@ -99,6 +99,7 @@ pub struct MlxConfig {
 /// `process_map_arc` is the shared session map from MlxState.
 pub async fn load_mlx_model_impl(
     process_map_arc: Arc<Mutex<HashMap<i32, MlxBackendSession>>>,
+    load_operation: Arc<Mutex<()>>,
     binary_path: &Path,
     model_id: String,
     model_path: String,
@@ -108,7 +109,7 @@ pub async fn load_mlx_model_impl(
     is_embedding: bool,
     timeout: u64,
 ) -> ServerResult<SessionInfo> {
-    let mut process_map = process_map_arc.lock().await;
+    let _load_guard = load_operation.lock().await;
 
     log::info!("Attempting to launch MLX server at path: {:?}", binary_path);
     log::info!("Using MLX configuration: {:?}", config);
@@ -298,10 +299,7 @@ pub async fn load_mlx_model_impl(
                         || line_lower.contains("ready to accept")
                         || line_lower.contains("server started and listening on")
                     {
-                        log::info!(
-                            "MLX server appears to be ready based on stdout: '{}'",
-                            line
-                        );
+                        log::info!("MLX server appears to be ready based on stdout: '{}'", line);
                         let _ = stdout_ready_tx.send(true).await;
                     }
                 }
@@ -341,10 +339,7 @@ pub async fn load_mlx_model_impl(
                             || line_lower.contains("server listening on")
                             || line_lower.contains("server started and listening on")
                         {
-                            log::info!(
-                                "MLX model appears to be ready based on logs: '{}'",
-                                line
-                            );
+                            log::info!("MLX model appears to be ready based on logs: '{}'", line);
                             let _ = ready_tx.send(true).await;
                         }
                     }
@@ -431,7 +426,7 @@ pub async fn load_mlx_model_impl(
         api_key: String::new(),
     };
 
-    process_map.insert(
+    process_map_arc.lock().await.insert(
         pid,
         MlxBackendSession {
             child,
@@ -468,6 +463,7 @@ pub async fn load_mlx_model<R: Runtime>(
         .join("resources/bin/mlx-server");
     load_mlx_model_impl(
         state.mlx_server_process.clone(),
+        state.load_operation.clone(),
         &binary_path,
         model_id,
         model_path,
@@ -487,9 +483,9 @@ pub async fn unload_mlx_model<R: Runtime>(
     pid: i32,
 ) -> ServerResult<UnloadResult> {
     let state: State<MlxState> = app_handle.state();
-    let mut map = state.mlx_server_process.lock().await;
+    let session = state.mlx_server_process.lock().await.remove(&pid);
 
-    if let Some(session) = map.remove(&pid) {
+    if let Some(session) = session {
         let mut child = session.child;
 
         #[cfg(unix)]
@@ -580,4 +576,46 @@ pub fn get_mlx_server_version<R: Runtime>(
         .to_string();
 
     Ok(MlxServerVersion { version, backend })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn early_load_error_does_not_wait_for_session_map_lock() {
+        let sessions = Arc::new(Mutex::new(HashMap::new()));
+        let load_operation = Arc::new(Mutex::new(()));
+        let _sessions_guard = sessions.lock().await;
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            load_mlx_model_impl(
+                sessions.clone(),
+                load_operation,
+                Path::new("/nonexistent/atomic-chat-mlx-server"),
+                "test-model".to_string(),
+                "/nonexistent/atomic-chat-mlx-model".to_string(),
+                1337,
+                MlxConfig {
+                    ctx_size: 0,
+                    draft_model_path: String::new(),
+                    block_size: 0,
+                    draft_kind: String::new(),
+                    kv_bits: 0.0,
+                    kv_quant_scheme: String::new(),
+                },
+                HashMap::new(),
+                false,
+                1,
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "early validation waited for the session map"
+        );
+        assert!(result.unwrap().is_err());
+    }
 }

--- a/src-tauri/plugins/tauri-plugin-mlx/src/state.rs
+++ b/src-tauri/plugins/tauri-plugin-mlx/src/state.rs
@@ -22,12 +22,14 @@ pub struct MlxBackendSession {
 /// MLX plugin state
 pub struct MlxState {
     pub mlx_server_process: Arc<Mutex<HashMap<i32, MlxBackendSession>>>,
+    pub load_operation: Arc<Mutex<()>>,
 }
 
 impl Default for MlxState {
     fn default() -> Self {
         Self {
             mlx_server_process: Arc::new(Mutex::new(HashMap::new())),
+            load_operation: Arc::new(Mutex::new(())),
         }
     }
 }

--- a/src-tauri/src/bin/jan-cli.rs
+++ b/src-tauri/src/bin/jan-cli.rs
@@ -405,6 +405,7 @@ async fn handle_models(cmd: ModelsCommands) {
 
             match load_mlx_model_impl(
                 mlx_state.mlx_server_process.clone(),
+                mlx_state.load_operation.clone(),
                 Path::new(&bin_path),
                 model_id,
                 resolved_model_path,
@@ -888,6 +889,7 @@ async fn handle_serve(args: ServeArgs) {
 
         match load_mlx_model_impl(
             mlx_state.mlx_server_process.clone(),
+            mlx_state.load_operation.clone(),
             Path::new(&bin_path),
             model_id.clone(),
             resolved_model_path,
@@ -1249,6 +1251,7 @@ async fn start_model_server(
         let effective_ctx_size = if fit { 0 } else { ctx_size };
         let info = match load_mlx_model_impl(
             mlx_state.mlx_server_process.clone(),
+            mlx_state.load_operation.clone(),
             Path::new(&bin_path),
             model_id.to_string(),
             model_path,

--- a/web-app/src/components/LogViewer.tsx
+++ b/web-app/src/components/LogViewer.tsx
@@ -75,7 +75,6 @@ export function LogViewer() {
       const date = new Date(timestamp)
       return date.toLocaleTimeString('en-US', {
         hour12: false,
-        timeZone: 'UTC',
         hour: '2-digit',
         minute: '2-digit',
         second: '2-digit'

--- a/web-app/src/components/MCPLogViewer.tsx
+++ b/web-app/src/components/MCPLogViewer.tsx
@@ -91,7 +91,6 @@ export function MCPLogViewer({ serverName }: Props) {
     const date = new Date(timestamp)
     return date.toLocaleTimeString('en-US', {
       hour12: false,
-      timeZone: 'UTC',
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',

--- a/web-app/src/routes/local-api-server/logs.tsx
+++ b/web-app/src/routes/local-api-server/logs.tsx
@@ -83,7 +83,6 @@ function LogsViewer() {
     const date = new Date(timestamp)
     return date.toLocaleTimeString('en-US', {
       hour12: false,
-      timeZone: 'UTC',
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit'

--- a/web-app/src/routes/logs.tsx
+++ b/web-app/src/routes/logs.tsx
@@ -75,7 +75,6 @@ function LogsViewer() {
     const date = new Date(timestamp)
     return date.toLocaleTimeString('en-US', {
       hour12: false,
-      timeZone: 'UTC',
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',

--- a/web-app/src/services/__tests__/app.test.ts
+++ b/web-app/src/services/__tests__/app.test.ts
@@ -73,11 +73,11 @@ describe('TauriAppService', () => {
 
   describe('parseLogLine', () => {
     it('should parse valid log line', () => {
-      const logLine = '[2024-01-01][10:00:00Z][target][INFO] Test message'
+      const logLine = '[2024-01-01][10:00:00][target][INFO] Test message'
       const result = appService.parseLogLine(logLine)
 
       expect(result).toEqual({
-        timestamp: '2024-01-01 10:00:00Z',
+        timestamp: '2024-01-01T10:00:00Z',
         level: 'info',
         target: 'target',
         message: 'Test message',

--- a/web-app/src/services/app/tauri.ts
+++ b/web-app/src/services/app/tauri.ts
@@ -84,9 +84,10 @@ export class TauriAppService extends DefaultAppService {
     const [, date, time, target, levelRaw, message] = match
 
     const level = levelRaw.toLowerCase() as 'info' | 'warn' | 'error' | 'debug'
+    const utcTime = time.endsWith('Z') ? time : `${time}Z`
 
     return {
-      timestamp: `${date} ${time}`,
+      timestamp: `${date}T${utcTime}`,
       level,
       target,
       message,


### PR DESCRIPTION
This commit introduces improvements to the loading of text-only MLX checkpoints by routing them through the appropriate model classification and handling failed loads more effectively. It implements a dedicated mutex for load operations to prevent session map lock contention, ensuring that failed or slow loads do not block the model loading process. Additionally, it updates the vision capability detection logic to utilize the new classification method, enhancing the overall robustness of the MLX extension. Verified by extensive testing across multiple components.

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
