### PR TITLE
fix(downloads): sanitize dots in download taskId so dotted model ids …

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -3206,7 +3206,10 @@ export default class llamacpp_extension extends AIEngine {
     // in the name (e.g. "Qwen3.5-9B-...", "Llama-3.1-8B-..."), and truncating
     // there collapsed distinct models onto the same taskId, causing one
     // download's cancellation to silently clobber another's cancel token.
-    return `${this.provider}/${modelId}`
+    // The taskId is embedded in a Tauri event name (`download-${taskId}`),
+    // and Tauri rejects any character outside [A-Za-z0-9_/:-] — so map the
+    // dot (and anything else forbidden) to '_' while keeping the full id.
+    return `${this.provider}/${modelId.replace(/[^A-Za-z0-9_/:-]/g, '_')}`
   }
 
   private async ensureBackendReady(

--- a/extensions/llamacpp-upstream-extension/src/index.ts
+++ b/extensions/llamacpp-upstream-extension/src/index.ts
@@ -4668,7 +4668,10 @@ export default class llamacpp_upstream_extension extends AIEngine {
     // in the name (e.g. "Qwen3.5-9B-...", "Llama-3.1-8B-..."), and truncating
     // there collapsed distinct models onto the same taskId, causing one
     // download's cancellation to silently clobber another's cancel token.
-    return `${this.provider}/${modelId}`
+    // The taskId is embedded in a Tauri event name (`download-${taskId}`),
+    // and Tauri rejects any character outside [A-Za-z0-9_/:-] — so map the
+    // dot (and anything else forbidden) to '_' while keeping the full id.
+    return `${this.provider}/${modelId.replace(/[^A-Za-z0-9_/:-]/g, '_')}`
   }
 
   /**

--- a/extensions/mlx-extension/src/index.ts
+++ b/extensions/mlx-extension/src/index.ts
@@ -1384,7 +1384,10 @@ export default class mlx_extension extends AIEngine {
     // in the name (e.g. "Qwen3.5-9B-...", "Llama-3.1-8B-..."), and truncating
     // there collapsed distinct models onto the same taskId, causing one
     // download's cancellation to silently clobber another's cancel token.
-    return `${this.provider}/${modelId}`
+    // The taskId is embedded in a Tauri event name (`download-${taskId}`),
+    // and Tauri rejects any character outside [A-Za-z0-9_/:-] — so map the
+    // dot (and anything else forbidden) to '_' while keeping the full id.
+    return `${this.provider}/${modelId.replace(/[^A-Za-z0-9_/:-]/g, '_')}`
   }
 
   override async abortImport(modelId: string): Promise<void> {

--- a/web-app/src/containers/MlxModelDownloadAction.tsx
+++ b/web-app/src/containers/MlxModelDownloadAction.tsx
@@ -170,7 +170,10 @@ export const MlxModelDownloadAction = memo(
             filename: file.rfilename,
           }))
 
-        return engine.import(modelId, {
+        // `await` is load-bearing: a bare `return engine.import(...)` inside
+        // try{} lets the rejection escape the catch — the download then fails
+        // with no toast, no console.error and a button stuck in "downloading".
+        return await engine.import(modelId, {
           modelPath: modelUrl,
           files: extraFiles,
           resume: resumableDownloads.has(modelId),


### PR DESCRIPTION
…(Qwen3.5 etc) download again

Regression from d43b2ab6c: removing the first-dot truncation put '.' into the Tauri event name (download-${taskId}), and Tauri rejects any event name outside [A-Za-z0-9_/:-]. listen() then failed before invoke('download_files'), so no download task was ever created — silently, because MlxModelDownloadAction returned engine.import() from inside try{} without await, letting the rejection escape the catch.

- createDownloadTaskId (mlx / llamacpp / llamacpp-upstream): map forbidden chars to '_' while keeping the full id (no cross-model collisions)
- MlxModelDownloadAction: return await engine.import(...) so failures surface as a toast instead of an unhandled rejection

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
