### PR TITLE
chore: pin llamacpp-upstream backend to b10063 (and fix macOS backend download URLs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -738,7 +738,7 @@ endif
 # the atomic-chat-conf manifest (Windows/Linux), e.g.:
 #   make download-llamacpp-upstream-backend LLAMACPP_UPSTREAM_TAG=b9222
 #   make download-llamacpp-upstream-backend LLAMACPP_UPSTREAM_TAG=
-LLAMACPP_UPSTREAM_TAG ?= b9937
+LLAMACPP_UPSTREAM_TAG ?= b10063
 download-llamacpp-upstream-backend:
 ifeq ($(shell uname -s),Darwin)
 	@rm -rf src-tauri/resources/llamacpp-backend-upstream

--- a/extensions/llamacpp-upstream-extension/src/backend.ts
+++ b/extensions/llamacpp-upstream-extension/src/backend.ts
@@ -443,14 +443,14 @@ export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
  * Builds the download URL for a specific backend version from ggml-org/llama.cpp.
  *
  * Asset naming differs by platform:
- *   - macOS: `llama-{tag}-bin-macos-{arm64,x64}.zip`
+ *   - macOS: `llama-{tag}-bin-macos-{arm64,x64}.tar.gz`
  *   - Windows: `llama-{tag}-bin-win-{variant}.zip`
  *   - Linux: `llama-{tag}-bin-ubuntu-{variant}.tar.gz` (note: internal
  *     backend ids are `linux-*` but upstream filenames carry `ubuntu-*`;
  *     `LINUX_UPSTREAM_ASSET_BY_BACKEND` provides the mapping).
  *
- * macOS / Windows use `.zip`, Linux uses `.tar.gz`. The Tauri `decompress`
- * command handles both formats transparently.
+ * Only Windows uses `.zip`; macOS and Linux use `.tar.gz`. The Tauri
+ * `decompress` command handles both formats transparently.
  */
 export function getBackendDownloadUrl(
   version: string,
@@ -472,6 +472,12 @@ export function getBackendDownloadUrl(
   if (linuxInfix) {
     return `${LLAMACPP_DOWNLOAD_BASE}/${version}/llama-${version}-bin-${linuxInfix}.tar.gz`
   }
+  // ggml-org publishes macOS backends only as `.tar.gz` (there is no macOS
+  // `.zip` asset), so a `.zip` URL here is a guaranteed 404 and the runtime
+  // backend download silently fails on macOS. Only Windows ships `.zip`.
+  if (backend.startsWith('macos-')) {
+    return `${LLAMACPP_DOWNLOAD_BASE}/${version}/llama-${version}-bin-${backend}.tar.gz`
+  }
   return `${LLAMACPP_DOWNLOAD_BASE}/${version}/llama-${version}-bin-${backend}.zip`
 }
 
@@ -481,6 +487,10 @@ export function getBackendArchiveName(version: string, backend: string): string 
   const linuxInfix = LINUX_UPSTREAM_ASSET_BY_BACKEND[backend]
   if (linuxInfix) {
     return `llama-${version}-bin-${linuxInfix}.tar.gz`
+  }
+  // Mirrors getBackendDownloadUrl: macOS assets are `.tar.gz`, not `.zip`.
+  if (backend.startsWith('macos-')) {
+    return `llama-${version}-bin-${backend}.tar.gz`
   }
   return `llama-${version}-bin-${backend}.zip`
 }

--- a/extensions/llamacpp-upstream-extension/src/backend.ts
+++ b/extensions/llamacpp-upstream-extension/src/backend.ts
@@ -39,14 +39,14 @@ const MANIFEST_FETCH_TIMEOUT_MS = 8_000
 // than the live manifest until the network recovers. Update this whenever
 // the atomic-chat-conf manifest is updated.
 const BUNDLED_MANIFEST_BASELINE = {
-  tag_name: 'b9937',
+  tag_name: 'b10063',
   assets: [
-    { name: 'llama-b9937-bin-win-cpu-x64.zip' },
-    { name: 'llama-b9937-bin-win-cuda-12.4-x64.zip' },
-    { name: 'llama-b9937-bin-win-cuda-13.3-x64.zip' },
-    { name: 'llama-b9937-bin-win-vulkan-x64.zip' },
-    { name: 'llama-b9937-bin-ubuntu-x64.tar.gz' },
-    { name: 'llama-b9937-bin-ubuntu-vulkan-x64.tar.gz' },
+    { name: 'llama-b10063-bin-win-cpu-x64.zip' },
+    { name: 'llama-b10063-bin-win-cuda-12.4-x64.zip' },
+    { name: 'llama-b10063-bin-win-cuda-13.3-x64.zip' },
+    { name: 'llama-b10063-bin-win-vulkan-x64.zip' },
+    { name: 'llama-b10063-bin-ubuntu-x64.tar.gz' },
+    { name: 'llama-b10063-bin-ubuntu-vulkan-x64.tar.gz' },
     { name: 'cudart-llama-bin-win-cuda-12.4-x64.zip' },
     { name: 'cudart-llama-bin-win-cuda-13.3-x64.zip' },
   ],

--- a/extensions/llamacpp-upstream-extension/src/index.ts
+++ b/extensions/llamacpp-upstream-extension/src/index.ts
@@ -4967,9 +4967,9 @@ export default class llamacpp_upstream_extension extends AIEngine {
    * Downloads a backend archive from ggml-org/llama.cpp GitHub releases
    * and extracts it into the local backends directory.
    *
-   * ggml-org publishes Windows and macOS backends as `.zip` archives
-   * (not `.tar.gz`). The Tauri `decompress` command handles both formats,
-   * so the extension change here is transparent to the extraction path.
+   * ggml-org publishes Windows backends as `.zip` archives and macOS /
+   * Linux backends as `.tar.gz`. The Tauri `decompress` command handles
+   * both formats, so the difference is transparent to the extraction path.
    */
   private async downloadAndInstallBackend(
     backendString: string

--- a/extensions/llamacpp-upstream-extension/src/index.ts
+++ b/extensions/llamacpp-upstream-extension/src/index.ts
@@ -194,7 +194,7 @@ function modelLoadReadyTimeoutSecs(configuredTimeoutSecs: number): number {
 /// (`LLAMACPP_UPSTREAM_TAG`) and `atomic-chat-conf/backends/manifest.json`
 /// (`tag_name`). Remove (or move to a real settings-driven pin) once the
 /// team is done validating this tag broadly. See `enforcePinnedBackendVersion`.
-const PINNED_BACKEND_TAG = 'b9937'
+const PINNED_BACKEND_TAG = 'b10063'
 
 /**
  * Override the default app.log function to use Jan's logging system.

--- a/extensions/llamacpp-upstream-extension/src/test/backend.test.ts
+++ b/extensions/llamacpp-upstream-extension/src/test/backend.test.ts
@@ -74,9 +74,19 @@ describe('Backend functions', () => {
       )
     })
 
-    it('keeps zip archive names for non-Linux backend archives', () => {
+    it('keeps zip archive names for Windows backend archives', () => {
       expect(getBackendArchiveName('b9691', 'win-cpu-x64')).toBe(
         'llama-b9691-bin-win-cpu-x64.zip'
+      )
+    })
+
+    it('uses tarball names for macOS backend archives', () => {
+      // ggml-org publishes macOS assets only as .tar.gz; a .zip name 404s.
+      expect(getBackendArchiveName('b9691', 'macos-arm64')).toBe(
+        'llama-b9691-bin-macos-arm64.tar.gz'
+      )
+      expect(getBackendArchiveName('b9691', 'macos-x64')).toBe(
+        'llama-b9691-bin-macos-x64.tar.gz'
       )
     })
   })


### PR DESCRIPTION
## Describe Your Changes

Bumps the pinned upstream llama.cpp backend from `b9937` to `b10063` so the
desktop app can run ternary models (e.g. the new Ternary-Bonsai family) on the
upstream backend — plus a fix this bump surfaced: **runtime backend downloads
on macOS were silently 404ing** because the extension built `.zip` asset URLs
while ggml-org publishes macOS builds only as `.tar.gz`. The bug was masked
until now because macOS normally gets the backend bundled into the app at
build time; the moment the pin outruns the bundled backend,
`enforcePinnedBackendVersion` hits the 404 and quietly keeps the old backend.
Second commit routes `macos-*` through `.tar.gz` naming (the Tauri
`decompress` command already handles both) with archive-name tests.

**Why:** mainline llama.cpp ternary `Q2_0` support landed after our pin. The
CPU kernels merged Jul 7 (ggml-org/llama.cpp#24448) and the Metal kernels
merged Jul 14 (ggml-org/llama.cpp#25419, first shipped in `b9994`); `b9937`
was cut Jul 9, so it has CPU but not Metal. Today no backend available in the
desktop app can load these models, while the mainline `Q2_0_g64` GGUFs run
fine on current upstream builds. (Vulkan and CUDA ternary kernels are still in
review upstream: ggml-org/llama.cpp#25430 and #25707, so those platforms gain
nothing yet but lose nothing either.)

**What's bumped** (the three mirrored pins):

- `PINNED_BACKEND_TAG` in `extensions/llamacpp-upstream-extension/src/index.ts`
- the offline fallback manifest in `extensions/llamacpp-upstream-extension/src/backend.ts`
- `LLAMACPP_UPSTREAM_TAG` in `Makefile`

The remote manifest in `atomic-chat-conf/backends/manifest.json` needs the
matching bump; opening that separately since it goes live for all installs the
moment it merges.

**Verification**

- Kernel-level: with the raw `b10063` `macos-arm64` release binaries,
  `prism-ml/Ternary-Bonsai-8B-gguf` `Q2_0_g64` (the mainline-format file)
  loads on an M3 Max with `254 q2_0 tensors` / `file type = Q2_0`, Metal
  initializes, and generation is coherent.
- End to end in a dev build of the app: without the tar.gz fix,
  `enforcePinnedBackendVersion` failed with `HTTP status 404 Not Found`; with
  it, the pin downloaded `llama-b10063-bin-macos-arm64.tar.gz`, logged
  `Backend b10063/macos-arm64 installed successfully`, and the installed
  binary reports `version: 10063`. The ternary 8B then loads and generates
  through the app on that backend (~704 t/s prompt / ~85 t/s gen at 5k
  context, clean stops, tool calls working).
- Confirmed all eight asset filenames referenced by the fallback manifest
  (win cpu/cuda-12.4/cuda-13.3/vulkan, ubuntu x64/vulkan, both cudart zips)
  exist verbatim on the `b10063` release.
- Extension tests: the new archive-name tests pass; the suite's pre-existing
  failures are identical on `main` (verified by stash-compare).

## Fixes Issues

- n/a (dependency bump; motivated by ternary model support)

## Self Checklist

- [x] Added relevant comments, esp in complex areas (why macOS routes to tar.gz)
- [ ] Updated docs (for bug fixes / features): n/a
- [ ] Created issues for follow-up changes or refactoring needed: noted the atomic-chat-conf manifest bump above

