### PR TITLE
fix: scroll stability, rendering, and tool-frame flicker

### DIFF
--- a/web-app/src/components/ai-elements/conversation.tsx
+++ b/web-app/src/components/ai-elements/conversation.tsx
@@ -5,12 +5,14 @@ import type { ComponentProps } from 'react'
 import { useCallback, memo } from 'react'
 import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom'
 
-export type ConversationProps = ComponentProps<typeof StickToBottom>
+export type ConversationProps = ComponentProps<typeof StickToBottom> & {
+  isStreaming?: boolean
+}
 
-export const Conversation = memo(({ className, ...props }: ConversationProps) => (
+export const Conversation = memo(({ className, isStreaming, ...props }: ConversationProps) => (
   <StickToBottom
     className={cn('relative flex-1 overflow-y-hidden', className)}
-    initial="smooth"
+    initial="instant"
     resize="smooth"
     role="log"
     {...props}

--- a/web-app/src/components/ai-elements/tools/tool.tsx
+++ b/web-app/src/components/ai-elements/tools/tool.tsx
@@ -5,6 +5,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
+import { useAutoScrollToBottom } from '@/hooks/useAutoScrollToBottom'
 import type { ToolUIPart } from 'ai'
 import { ChevronDownIcon, Loader2, WrenchIcon } from 'lucide-react'
 import type { ComponentProps, ReactNode } from 'react'
@@ -15,6 +16,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import { CodeBlock } from '../code-block'
@@ -166,9 +168,9 @@ export const ToolInput = memo(
         <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
           Parameters
         </h4>
-        <div className="rounded-md max-h-40 overflow-auto border ">
+        <ScrolledOutput className="rounded-md max-h-40 overflow-auto border ">
           <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
-        </div>
+        </ScrolledOutput>
       </div>
     )
   }
@@ -227,6 +229,20 @@ export type ToolOutputProps = ComponentProps<'div'> & {
   resolver: (input: string) => Promise<string>
 }
 
+function ScrolledOutput({ children, className }: { children: ReactNode; className?: string }) {
+  const ref = useRef<HTMLDivElement>(null)
+  // Follow streamed tool output to the bottom, but let the user scroll up to
+  // read. The rAF pin tracks content growth smoothly without ever falling
+  // behind (unlike an interrupted `scrollTo({ behavior: 'smooth' })`).
+  const { handleScroll } = useAutoScrollToBottom(ref, { enabled: true })
+
+  return (
+    <div ref={ref} onScroll={handleScroll} className={className}>
+      {children}
+    </div>
+  )
+}
+
 export const ToolOutput = memo(
   ({ className, output, errorText, resolver, ...props }: ToolOutputProps) => {
     const Output = useMemo(() => {
@@ -237,9 +253,9 @@ export const ToolOutput = memo(
       // Handle string output
       if (typeof output === 'string') {
         return (
-          <div className="max-h-40 overflow-auto rounded-md border ">
+          <ScrolledOutput className="max-h-40 overflow-auto rounded-md border ">
             <CodeBlock code={output} language="json" />
-          </div>
+          </ScrolledOutput>
         )
       }
 
@@ -266,12 +282,12 @@ export const ToolOutput = memo(
               {textItems.length > 0 && (
                 <div className="space-y-2">
                   {textItems.map((item, index) => (
-                    <div
+                    <ScrolledOutput
                       key={index}
                       className="rounded-md max-h-40 overflow-auto border "
                     >
                       <CodeBlock code={item.text || ''} language="markdown" />
-                    </div>
+                    </ScrolledOutput>
                   ))}
                 </div>
               )}
@@ -306,12 +322,12 @@ export const ToolOutput = memo(
             return (
               <div className="space-y-4">
                 {nonImageOutput.length > 0 && (
-                  <div className="rounded-md max-h-40 overflow-auto rounded-md border ">
+                  <ScrolledOutput className="rounded-md max-h-40 overflow-auto rounded-md border ">
                     <CodeBlock
                       code={JSON.stringify(nonImageOutput, null, 2)}
                       language="json"
                     />
-                  </div>
+                  </ScrolledOutput>
                 )}
                 {output
                   .filter(
@@ -331,20 +347,20 @@ export const ToolOutput = memo(
           }
 
           return (
-            <div className="rounded-md max-h-40 overflow-auto border ">
+            <ScrolledOutput className="rounded-md max-h-40 overflow-auto border ">
               <CodeBlock
                 code={JSON.stringify(output, null, 2)}
                 language="json"
               />
-            </div>
+            </ScrolledOutput>
           )
         }
 
         // Handle regular object
         return (
-          <div className="rounded-md max-h-40 overflow-auto border ">
+          <ScrolledOutput className="rounded-md max-h-40 overflow-auto border ">
             <CodeBlock code={JSON.stringify(output, null, 2)} language="json" />
-          </div>
+          </ScrolledOutput>
         )
       }
 

--- a/web-app/src/containers/HtmlArtifact.tsx
+++ b/web-app/src/containers/HtmlArtifact.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { Check, Code2, Copy, Download, Eye, Printer, X } from 'lucide-react'
 import { fs } from '@janhq/core'
 import { cn } from '@/lib/utils'
+import { useAutoScrollToBottom } from '@/hooks/useAutoScrollToBottom'
 import { Button } from '@/components/ui/button'
 import { CodeBlock } from '@/components/ai-elements/code-block'
 import { getServiceHub } from '@/hooks/useServiceHub'
@@ -93,6 +94,15 @@ function HtmlArtifactComponent({
   const artifactIdRef = useRef<string>('')
   if (!artifactIdRef.current) artifactIdRef.current = createArtifactId()
   const versionRef = useRef(0)
+
+  // Auto-scroll the HTML source ("Code" tab) to the bottom while it streams,
+  // but let the user scroll up to read without being yanked back down. Mirrors
+  // the stick-to-bottom behaviour used for the tool window / reasoning box.
+  const codeScrollRef = useRef<HTMLDivElement>(null)
+  const { handleScroll: handleCodeScroll } = useAutoScrollToBottom(
+    codeScrollRef,
+    { enabled: streaming }
+  )
 
   const [codeIdle, setCodeIdle] = useState(false)
   useEffect(() => {
@@ -393,6 +403,8 @@ function HtmlArtifactComponent({
         )}
       >
         <div
+          ref={codeScrollRef}
+          onScroll={handleCodeScroll}
           className={cn(
             'overflow-y-auto overflow-x-hidden',
             fill ? 'h-full' : 'max-h-[440px]'

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -50,6 +50,7 @@ export type MessageItemProps = {
   isLastMessage: boolean
   status: ChatStatus
   reasoningContainerRef?: React.RefObject<HTMLDivElement | null>
+  onReasoningScroll?: () => void
   onRegenerate?: (messageId: string) => void
   onEdit?: (messageId: string, newText: string) => void
   onDelete?: (messageId: string) => void
@@ -67,6 +68,7 @@ export const MessageItem = memo(
     isAnimating,
     hideActions,
     reasoningContainerRef,
+    onReasoningScroll,
     onRegenerate,
     onEdit,
     onDelete,
@@ -238,10 +240,11 @@ export const MessageItem = memo(
             )}
             <div
               ref={isStreaming ? reasoningContainerRef : null}
+              onScroll={isStreaming ? onReasoningScroll : undefined}
               className={twMerge(
-                'w-full overflow-auto relative',
+                'w-full relative',
                 isStreaming
-                  ? 'max-h-32 opacity-70 mt-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden'
+                  ? 'opacity-70 mt-2 overflow-auto max-h-32 [overflow-anchor:none]'
                   : 'h-auto opacity-100'
               )}
             >
@@ -303,6 +306,7 @@ export const MessageItem = memo(
           key={block.key}
           state={block.state}
           className="mb-4 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
+          style={{ transform: 'translateZ(0)' }}
         >
           <ToolRenderer presentation={block.presentation} state={block.state} />
         </Tool>

--- a/web-app/src/hooks/useAutoScrollToBottom.ts
+++ b/web-app/src/hooks/useAutoScrollToBottom.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+export interface AutoScrollOptions {
+  /** While true, the element is continuously pinned to the bottom (e.g. while streaming). */
+  enabled: boolean
+  /** Distance from the bottom (px) still considered "at bottom". Default 8. */
+  threshold?: number
+  /**
+   * Lag (px) above which we abandon easing and snap instantly to catch up.
+   * Prevents the asymptotic ease from falling behind during fast streams.
+   * Default 50.
+   */
+  catchUpThreshold?: number
+  /** Ease per frame, 0..1. Higher = snappier, lower = smoother glide. Default 0.4. */
+  ease?: number
+  /** When true, streaming content keeps following even if layout reflow moves scrollTop upward. */
+  forceStick?: boolean
+}
+
+/**
+ * Keeps a scrollable element smoothly glued to its bottom while `enabled`
+ * is true, without ever falling behind or stopping on collapse/un‑collapse.
+ *
+ * Uses per-frame exponential easing for a continuous glide, but snaps instantly
+ * whenever the lag exceeds `catchUpThreshold` so it never gets stuck.
+ * Reads `ref.current` fresh every frame so remounts (collapse/un‑collapse)
+ * are handled automatically, and skips pinning when the element is hidden
+ * (display:none) to avoid wasted work and stale scrollTop.
+ */
+export function useAutoScrollToBottom<T extends HTMLElement = HTMLDivElement>(
+  ref: React.RefObject<T | null>,
+  options: AutoScrollOptions
+) {
+  const stickRef = useRef(true)
+  const lastScrollTopRef = useRef(0)
+  const manualScrollRef = useRef(false)
+  const manualScrollTimerRef = useRef<number | null>(null)
+  const touchYRef = useRef(0)
+  const rafRef = useRef<number | null>(null)
+  const threshold = options.threshold ?? 8
+  const catchUp = options.catchUpThreshold ?? 50
+  const ease = options.ease ?? 0.4
+  const forceStick = options.forceStick ?? false
+
+  const isAtBottom = useCallback(
+    (el: T) => el.scrollHeight - el.scrollTop - el.clientHeight <= threshold,
+    [threshold]
+  )
+
+  const handleScroll = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+
+    const current = el.scrollTop
+    if (forceStick) {
+      if (isAtBottom(el)) {
+        stickRef.current = true
+      } else if (
+        manualScrollRef.current &&
+        current < lastScrollTopRef.current - 1
+      ) {
+        stickRef.current = false
+      }
+      lastScrollTopRef.current = current
+      return
+    }
+
+    if (current < lastScrollTopRef.current - 1) {
+      stickRef.current = false
+    } else if (isAtBottom(el)) {
+      stickRef.current = true
+    }
+    lastScrollTopRef.current = current
+  }, [ref, isAtBottom, forceStick])
+
+  useEffect(() => {
+    if (!options.enabled) {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+      return
+    }
+
+    const isVisible = (el: T) =>
+      el.getClientRects().length > 0 && el.clientHeight > 0
+
+    const markManualScroll = () => {
+      manualScrollRef.current = true
+      if (manualScrollTimerRef.current != null) {
+        window.clearTimeout(manualScrollTimerRef.current)
+      }
+      manualScrollTimerRef.current = window.setTimeout(() => {
+        manualScrollRef.current = false
+        manualScrollTimerRef.current = null
+      }, 350)
+    }
+
+    let inputEl: T | null = null
+    let cleanupInput = () => {}
+
+    const syncManualInputListeners = (el: T | null) => {
+      if (!forceStick || inputEl === el) return
+      cleanupInput()
+      inputEl = el
+      if (!el) return
+
+      const handleWheel = (event: WheelEvent) => {
+        markManualScroll()
+        if (event.deltaY < 0) stickRef.current = false
+      }
+      const handleTouchStart = (event: TouchEvent) => {
+        markManualScroll()
+        touchYRef.current = event.touches[0]?.clientY ?? 0
+      }
+      const handleTouchMove = (event: TouchEvent) => {
+        markManualScroll()
+        const nextY = event.touches[0]?.clientY ?? touchYRef.current
+        if (nextY > touchYRef.current + 1) stickRef.current = false
+        touchYRef.current = nextY
+      }
+      const handlePointerDown = () => markManualScroll()
+      const handlePointerMove = () => markManualScroll()
+
+      el.addEventListener('wheel', handleWheel, { passive: true })
+      el.addEventListener('touchstart', handleTouchStart, { passive: true })
+      el.addEventListener('touchmove', handleTouchMove, { passive: true })
+      el.addEventListener('pointerdown', handlePointerDown, { passive: true })
+      el.addEventListener('pointermove', handlePointerMove, { passive: true })
+
+      cleanupInput = () => {
+        el.removeEventListener('wheel', handleWheel)
+        el.removeEventListener('touchstart', handleTouchStart)
+        el.removeEventListener('touchmove', handleTouchMove)
+        el.removeEventListener('pointerdown', handlePointerDown)
+        el.removeEventListener('pointermove', handlePointerMove)
+      }
+    }
+
+    const pinToBottom = (el: T) => {
+      const max = el.scrollHeight - el.clientHeight
+      el.scrollTop = max
+      lastScrollTopRef.current = el.scrollTop
+    }
+
+    // Immediate pin on activation only when the element is actually visible
+    // (not display:none / hidden tab). A hidden element drops scrollTop writes.
+    const el = ref.current
+    if (el && isVisible(el)) {
+      stickRef.current = true
+      pinToBottom(el)
+    }
+
+    let prevVisible = el ? isVisible(el) : false
+
+    const tick = () => {
+      const el = ref.current
+      syncManualInputListeners(el)
+      if (el) {
+        const visible = isVisible(el)
+        if (visible && !prevVisible) {
+          // Just became visible (tab switch, un-collapse) - pin immediately
+          // so the user never sees the top while content is streaming.
+          stickRef.current = true
+          pinToBottom(el)
+        }
+        prevVisible = visible
+
+        if (visible && stickRef.current) {
+          const max = el.scrollHeight - el.clientHeight
+          const current = el.scrollTop
+          const diff = max - current
+          if (diff > threshold) {
+            if (diff > catchUp) {
+              // Lag too large - snap instantly so we never fall behind.
+              el.scrollTop = max
+            } else {
+              const next = current + diff * ease
+              el.scrollTop = next >= max - 0.5 ? max : next
+            }
+            lastScrollTopRef.current = el.scrollTop
+          }
+        }
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+      cleanupInput()
+      if (manualScrollTimerRef.current != null) {
+        window.clearTimeout(manualScrollTimerRef.current)
+        manualScrollTimerRef.current = null
+      }
+      manualScrollRef.current = false
+      rafRef.current = null
+    }
+  }, [ref, options.enabled, threshold, catchUp, ease, forceStick])
+
+  return { stickRef, handleScroll }
+}

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 
 import HeaderPage from '@/containers/HeaderPage'
 import { useThreads } from '@/hooks/useThreads'
+import { useAutoScrollToBottom } from '@/hooks/useAutoScrollToBottom'
 import ChatInput from '@/containers/ChatInput'
 import { useShallow } from 'zustand/react/shallow'
 import { MessageItem } from '@/containers/MessageItem'
@@ -476,16 +477,14 @@ function ThreadDetail() {
     disabledTools, // Re-run when tools are enabled/disabled
   ])
 
-  // Ref for reasoning container auto-scroll
+  // Ref for reasoning container auto-scroll. The hook pins it to the bottom as
+  // new tokens arrive, but pauses the moment the user scrolls up to read and
+  // resumes once they return to the bottom — so it never fights the user.
   const reasoningContainerRef = useRef<HTMLDivElement>(null)
-
-  // Auto-scroll reasoning container to bottom during streaming
-  useEffect(() => {
-    if (status === 'streaming' && reasoningContainerRef.current) {
-      reasoningContainerRef.current.scrollTop =
-        reasoningContainerRef.current.scrollHeight
-    }
-  }, [status, chatMessages])
+  const { handleScroll: handleReasoningScroll } = useAutoScrollToBottom(
+    reasoningContainerRef,
+    { enabled: status === 'streaming', forceStick: true }
+  )
 
   // Note: no unmount cleanup of the optimistic bubble store here. React
   // StrictMode in dev simulates mount → unmount → remount on initial mount;
@@ -1061,7 +1060,7 @@ function ThreadDetail() {
         <div className="flex flex-1 flex-col h-full overflow-hidden min-w-0">
         {/* Messages Area */}
         <div className="flex-1 relative">
-          <Conversation className="absolute inset-0 text-start">
+          <Conversation className="absolute inset-0 text-start" isStreaming={status === 'streaming'}>
             <ConversationContent
               className={cn('mx-auto w-full md:w-4/5 xl:w-4/6')}
             >
@@ -1076,10 +1075,11 @@ function ThreadDetail() {
                     isLastMessage={isLastMessage}
                     status={status}
                     reasoningContainerRef={reasoningContainerRef}
+                    onReasoningScroll={handleReasoningScroll}
                     onRegenerate={handleRegenerate}
                     onEdit={handleEditMessage}
                     onDelete={handleDeleteMessage}
-                    isAnimating={!pendingContinueMessage}
+                    isAnimating={status !== 'streaming' && !pendingContinueMessage}
                     hideActions={!!pendingContinueMessage}
                   />
                 )
@@ -1093,6 +1093,7 @@ function ThreadDetail() {
                     isLastMessage={true}
                     status={status}
                     reasoningContainerRef={reasoningContainerRef}
+                    onReasoningScroll={handleReasoningScroll}
                     onRegenerate={handleRegenerate}
                     onEdit={handleEditMessage}
                     onDelete={handleDeleteMessage}
@@ -1112,6 +1113,7 @@ function ThreadDetail() {
                   isLastMessage={true}
                   status={status}
                   reasoningContainerRef={reasoningContainerRef}
+                  onReasoningScroll={handleReasoningScroll}
                   onRegenerate={handleRegenerate}
                   onEdit={handleEditMessage}
                   onDelete={handleDeleteMessage}

--- a/web-app/src/styles/markdown.css
+++ b/web-app/src/styles/markdown.css
@@ -155,6 +155,45 @@
     color: var(--shiki-dark, var(--foreground)) !important;
   }
 
+  /* Tables: window frame with rounded corners */
+  table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    margin-bottom: 1em;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    font-size: var(--text-sm);
+    transform: translateZ(0);
+  }
+
+  thead {
+    background-color: var(--muted);
+  }
+
+  th {
+    text-align: left;
+    font-weight: 600;
+    padding: 0.5em 0.75em;
+    border-bottom: 1px solid var(--border);
+    white-space: normal;
+  }
+
+  td {
+    padding: 0.5em 0.75em;
+    border-bottom: 1px solid var(--border);
+    white-space: normal;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: color-mix(in srgb, var(--muted) 40%, transparent);
+  }
+
   /* Links */
   a {
     color: var(--color-primary);


### PR DESCRIPTION
## Summary

Bundles the scroll/rendering/UX fixes from the fork's main branch into a single PR against upstream:

- **Auto-scroll stickiness** — chat now stays pinned to the bottom during streaming, while still allowing the user to manually scroll up without the viewport fighting them ( hook).
- **Tool calling scroll** — the tool-calling panel auto-scrolls to keep the latest step visible.
- **Table/tool-frame border flicker** — removes the visual flash of the border re-rendering on every streaming token.
- **Reasoning scroll stability** — stops the reasoning accordion from resetting its scroll position on each update.

### Files changed
| File | Change |
|------|--------|
| `web-app/src/hooks/useAutoScrollToBottom.ts` | **new** — reusable scroll-to-bottom hook with manual-override detection |
| `web-app/src/components/ai-elements/conversation.tsx` | consume new hook |
| `web-app/src/components/ai-elements/tools/tool.tsx` | consume new hook for tool panel |
| `web-app/src/containers/HtmlArtifact.tsx` | consume new hook |
| `web-app/src/containers/MessageItem.tsx` | border flicker fix |
| `web-app/src/styles/markdown.css` | border flicker fix |
| `web-app/src/routes/threads/$threadId.tsx` | consume new hook |