### PR TITLE
fix: repin 26B Gemma MTP head sha256 to regenerated assistant

### DIFF
--- a/extensions/llamacpp-upstream-extension/src/gemmaMtpRegistry.ts
+++ b/extensions/llamacpp-upstream-extension/src/gemmaMtpRegistry.ts
@@ -61,9 +61,12 @@ const REGISTRY: readonly GemmaMtpRegistryEntry[] = [
       id.includes('a4b'),
     repo: 'AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF',
     draftFilename: 'gemma-4-26B-A4B-it-assistant.Q8_0.gguf',
+    // 2026-07-23: assistant repos were regenerated in the post-b10018
+    // gemma4-assistant format (the old heads no longer load on engine
+    // b10018-1.1.1+), so the pin tracks the re-uploaded file.
     draftSha256:
-      '0ff5e851eb69aba552efb7cc5da0b37801b42554b403f8584e0b83b92296f69d',
-    draftSize: 461767072,
+      '918d48b5c219035561e0ff791f2926c939cd367d71ee21b002e99222bdecab8b',
+    draftSize: 461766880,
   },
 ]
 


### PR DESCRIPTION
The assistant GGUF repos were regenerated in the post-b10018 format on 2026-07-23 (the old heads cannot be loaded by engine b10018-1.1.1+). The 26B MTP auto-download pins sha256+size of the old `gemma-4-26B-A4B-it-assistant.Q8_0.gguf` and now hard-fails validation.

- new sha256: `918d48b5c219035561e0ff791f2926c939cd367d71ee21b002e99222bdecab8b`, size 461766880 (verified against both the local artifact and the HF LFS oid)
- 31B entry (am17an head) checked: already new-format `gemma4-assistant`, pin still valid, untouched

Release-blocking for the Gemma MTP path; no other changes.