### PR TITLE
Enhance Rust Agent evaluation with headless `gaia-eval` binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,27 @@ Append-only. Newest at top. Each entry follows this shape:
 
 ---
 
+### 2026-07-27 — Evaluate the Rust Agent sequentially on gated GAIA validation
+- **Context:** Atomic Chat needed a repeatable benchmark for its direct Rust
+  Agent loop that fits one local model in memory and does not depend on the
+  Tauri UI or IPC.
+- **Decision:** Add a feature-gated headless `gaia-eval` binary and
+  `make gaia-eval`. Load and cache the official gated GAIA 2023 validation
+  split through Hugging Face, start one dedicated `llama-server` with one
+  slot, and call `core::agent::runner::run_turn` directly for isolated tasks
+  in a strictly sequential loop. Keep workspace path policy, shell hard
+  blocks, SSRF protections, task timeouts, event capture, GAIA-compatible
+  scoring, and JSON plus terminal reporting.
+- **Consequences:** Local models can be compared through one reproducible
+  command without competing inference jobs or GUI state. A valid gated
+  Hugging Face token and local server/model paths remain operator
+  prerequisites. Parallel execution is deliberately deferred until models
+  or hardware can support multiple independent slots.
+- **Owner:** team.
+- **Links:** [`src-tauri/src/core/agent/eval/`](src-tauri/src/core/agent/eval/),
+  [`src-tauri/src/bin/gaia-eval.rs`](src-tauri/src/bin/gaia-eval.rs),
+  [`Makefile`](Makefile) (`gaia-eval`).
+
 ### 2026-07-24 — Let users revoke or downgrade Agent folder access
 - **Context:** Connected external Agent folders were permanently editable for
   the thread and had no management controls after being added.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,24 @@ Append-only. Newest at top. Each entry follows this shape:
 
 ---
 
+### 2026-07-27 — Run Windows GAIA evaluation on the selected upstream GPU backend
+- **Context:** `make gaia-eval` inherited the macOS-oriented TurboQuant
+  `llama-server` path on every platform. On Windows this omitted `.exe` and
+  selected the bundled TurboQuant CPU fallback even when development setup had
+  already installed the hardware-selected upstream backend, such as
+  `win-cuda-13.3-x64`.
+- **Decision:** Default `GAIA_LLAMA_SERVER` on Windows to the prepared
+  `llamacpp-backend-upstream/build/bin/llama-server.exe`. Preserve the existing
+  TurboQuant default on other platforms and preserve an explicit
+  `GAIA_LLAMA_SERVER` override everywhere.
+- **Consequences:** Windows GAIA runs use the same CUDA 13, CUDA 12, Vulkan, or
+  CPU upstream binary selected by the existing Windows backend setup instead
+  of silently benchmarking the TurboQuant CPU fallback. GAIA does not download
+  or replace backends itself; the selected resource must already exist.
+- **Owner:** team.
+- **Links:** [`Makefile`](Makefile) (`GAIA_LLAMA_SERVER`, `gaia-eval`),
+  [`scripts/dev-windows.ps1`](scripts/dev-windows.ps1).
+
 ### 2026-07-27 — Evaluate the Rust Agent sequentially on gated GAIA validation
 - **Context:** Atomic Chat needed a repeatable benchmark for its direct Rust
   Agent loop that fits one local model in memory and does not depend on the
@@ -319,12 +337,14 @@ Append-only. Newest at top. Each entry follows this shape:
   slot, and call `core::agent::runner::run_turn` directly for isolated tasks
   in a strictly sequential loop. Keep workspace path policy, shell hard
   blocks, SSRF protections, task timeouts, event capture, GAIA-compatible
-  scoring, and JSON plus terminal reporting.
+  scoring, and JSON plus terminal reporting. Default runs to Level 1 while
+  retaining `GAIA_LEVEL` / `--level` as an explicit override.
 - **Consequences:** Local models can be compared through one reproducible
   command without competing inference jobs or GUI state. A valid gated
   Hugging Face token and local server/model paths remain operator
-  prerequisites. Parallel execution is deliberately deferred until models
-  or hardware can support multiple independent slots.
+  prerequisites. Unconfigured runs cover only Level 1; Levels 2 and 3 require
+  an explicit filter. Parallel execution is deliberately deferred until
+  models or hardware can support multiple independent slots.
 - **Owner:** team.
 - **Links:** [`src-tauri/src/core/agent/eval/`](src-tauri/src/core/agent/eval/),
   [`src-tauri/src/bin/gaia-eval.rs`](src-tauri/src/bin/gaia-eval.rs),

--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,8 @@ test-agent:
 
 ATOMIC_AGENT_E2E_LLAMA_SERVER ?= $(CURDIR)/src-tauri/resources/llamacpp-backend/build/bin/llama-server
 ATOMIC_AGENT_E2E_MODEL ?= $(HOME)/Library/Application Support/Atomic Chat/data/llamacpp/models/unsloth/Qwen3_5-9B-GGUF-Qwen3_5-9B-IQ4_XS/model.gguf
+GAIA_LLAMA_SERVER ?= $(ATOMIC_AGENT_E2E_LLAMA_SERVER)
+GAIA_MODEL ?= $(ATOMIC_AGENT_E2E_MODEL)
 
 test-agent-model:
 	@test -x "$(ATOMIC_AGENT_E2E_LLAMA_SERVER)" || (echo "llama-server not found: $(ATOMIC_AGENT_E2E_LLAMA_SERVER)" && exit 1)
@@ -284,6 +286,15 @@ test-agent-model:
 	ATOMIC_AGENT_E2E_MODEL="$(ATOMIC_AGENT_E2E_MODEL)" \
 	cargo test --manifest-path src-tauri/Cargo.toml -p Atomic-Chat \
 		managed_model_agent_scenarios -- --ignored --nocapture --test-threads=1
+
+.PHONY: gaia-eval
+gaia-eval:
+	@test -x "$(GAIA_LLAMA_SERVER)" || (echo "llama-server not found or not executable: $(GAIA_LLAMA_SERVER)" && exit 1)
+	@test -f "$(GAIA_MODEL)" || (echo "model not found: $(GAIA_MODEL)" && exit 1)
+	GAIA_LLAMA_SERVER="$(GAIA_LLAMA_SERVER)" \
+	GAIA_MODEL="$(GAIA_MODEL)" \
+	cargo run --manifest-path src-tauri/Cargo.toml -p Atomic-Chat \
+		--features gaia-eval --bin gaia-eval
 
 test: lint install-rust-targets
 	yarn download:bin

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,11 @@ test-agent:
 
 ATOMIC_AGENT_E2E_LLAMA_SERVER ?= $(CURDIR)/src-tauri/resources/llamacpp-backend/build/bin/llama-server
 ATOMIC_AGENT_E2E_MODEL ?= $(HOME)/Library/Application Support/Atomic Chat/data/llamacpp/models/unsloth/Qwen3_5-9B-GGUF-Qwen3_5-9B-IQ4_XS/model.gguf
+ifeq ($(OS),Windows_NT)
+GAIA_LLAMA_SERVER ?= $(CURDIR)/src-tauri/resources/llamacpp-backend-upstream/build/bin/llama-server.exe
+else
 GAIA_LLAMA_SERVER ?= $(ATOMIC_AGENT_E2E_LLAMA_SERVER)
+endif
 GAIA_MODEL ?= $(ATOMIC_AGENT_E2E_MODEL)
 
 test-agent-model:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "nix",
  "notify-rust",
  "once_cell",
+ "parquet",
  "png 0.18.1",
  "rand 0.8.5",
  "regex",
@@ -138,6 +139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -151,6 +153,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -600,6 +617,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -2622,6 +2660,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -3236,6 +3275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,6 +3668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash 2.1.3",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,6 +3968,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3927,6 +4004,15 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3951,6 +4037,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
  "num-integer",
  "num-traits",
 ]
@@ -4336,6 +4432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,6 +4552,32 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parquet"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb15796ac6f56b429fd99e33ba133783ad75b27c36b4b5ce06f1f82cc97754e"
+dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.15.5",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "serde_json",
+ "snap",
+ "thrift",
+ "twox-hash 1.6.3",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -6182,6 +6313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6497,6 +6634,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -7824,6 +7967,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8210,6 +8364,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "type1-encoding-parser"
@@ -10008,7 +10178,7 @@ dependencies = [
  "pbkdf2",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -10035,7 +10205,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -10045,6 +10224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,11 @@ name = "jan-cli"
 path = "src/bin/jan-cli.rs"
 required-features = ["cli"]
 
+[[bin]]
+name = "gaia-eval"
+path = "src/bin/gaia-eval.rs"
+required-features = ["gaia-eval"]
+
 [features]
 default = [
     "tauri/wry",
@@ -57,6 +62,7 @@ test-tauri = [
     "desktop",
 ]
 cli = ["dep:env_logger", "dep:dialoguer", "dep:indicatif", "dep:console"]
+gaia-eval = ["dep:env_logger", "dep:indicatif", "dep:parquet"]
 
 [build-dependencies]
 tauri-build = { version = "2.0.2", features = [] }
@@ -126,7 +132,7 @@ sysinfo = "0.34.2"
 hostname = "0.4"
 base64 = "0.22"
 glob = "0.3"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 dialoguer = { version = "0.11", optional = true }
 env_logger = { version = "0.11", optional = true }
 indicatif = { version = "0.17", optional = true }
@@ -135,6 +141,7 @@ ignore = "=0.4.30"
 regex = "1.13.1"
 diffy = "0.4.2"
 trash = "=5.2.3"
+parquet = { version = "54.3.1", default-features = false, features = ["brotli", "flate2", "json", "lz4", "snap", "zstd"], optional = true }
 
 [dependencies.tauri]
 version = "2.8.5"

--- a/src-tauri/src/bin/gaia-eval.rs
+++ b/src-tauri/src/bin/gaia-eval.rs
@@ -1,0 +1,59 @@
+use clap::Parser;
+use std::path::Path;
+use std::process::ExitCode;
+
+use app_lib::core::agent::eval::{run, GaiaEvalArgs};
+
+fn load_gaia_dotenv() {
+    let env_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".env");
+    let Ok(contents) = std::fs::read_to_string(env_path) else {
+        return;
+    };
+
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((raw_key, raw_value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = raw_key.trim();
+        if key != "HF_TOKEN" && !key.starts_with("GAIA_") {
+            continue;
+        }
+        if std::env::var(key).is_ok_and(|value| !value.trim().is_empty()) {
+            continue;
+        }
+        let value = raw_value
+            .trim()
+            .trim_matches(|character| character == '"' || character == '\'');
+        std::env::set_var(key, value);
+    }
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    load_gaia_dotenv();
+    env_logger::init();
+    let args = GaiaEvalArgs::parse();
+    tokio::select! {
+        result = run(args) => {
+            if let Err(error) = result {
+                eprintln!("GAIA evaluation failed: {error}");
+                ExitCode::FAILURE
+            } else {
+                ExitCode::SUCCESS
+            }
+        }
+        signal = tokio::signal::ctrl_c() => {
+            if let Err(error) = signal {
+                eprintln!("Failed to listen for Ctrl-C: {error}");
+                ExitCode::FAILURE
+            } else {
+                eprintln!("GAIA evaluation interrupted");
+                ExitCode::from(130)
+            }
+        }
+    }
+}

--- a/src-tauri/src/core/agent/eval/dataset.rs
+++ b/src-tauri/src/core/agent/eval/dataset.rs
@@ -1,0 +1,459 @@
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const DATASET_ID: &str = "gaia-benchmark/GAIA";
+const DATASET_CONFIG: &str = "2023_all";
+const DATASET_SPLIT: &str = "validation";
+const DATASET_PARQUET_API_BASE: &str = "https://huggingface.co/api/datasets";
+const PAGE_SIZE: usize = 100;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GaiaTask {
+    pub task_id: String,
+    pub question: String,
+    pub level: u8,
+    pub gold_answer: String,
+    pub file_name: Option<String>,
+    pub file_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GaiaFilters {
+    pub level: Option<u8>,
+    pub limit: Option<usize>,
+    pub task_id: Option<String>,
+}
+
+pub struct GaiaDatasetClient {
+    client: reqwest::Client,
+    token: String,
+    cache_dir: PathBuf,
+}
+
+impl GaiaDatasetClient {
+    pub fn new(token: String, cache_dir: PathBuf) -> Result<Self, String> {
+        if token.trim().is_empty() {
+            return Err("GAIA_HF_TOKEN or HF_TOKEN is required".into());
+        }
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .map_err(|error| format!("Failed to create Hugging Face client: {error}"))?;
+        Ok(Self {
+            client,
+            token,
+            cache_dir,
+        })
+    }
+
+    pub async fn load_tasks(&self, filters: &GaiaFilters) -> Result<Vec<GaiaTask>, String> {
+        std::fs::create_dir_all(&self.cache_dir)
+            .map_err(|error| format!("Failed to create GAIA cache: {error}"))?;
+        let mut tasks = Vec::new();
+        let mut offset = 0;
+        loop {
+            let page_path = self.cache_dir.join(format!("rows-{offset}.json"));
+            let page = if page_path.is_file() {
+                std::fs::read(&page_path)
+                    .map_err(|error| format!("Failed to read {}: {error}", page_path.display()))?
+            } else {
+                let url = format!(
+                    "https://datasets-server.huggingface.co/rows?dataset={DATASET_ID}&config={DATASET_CONFIG}&split={DATASET_SPLIT}&offset={offset}&length={PAGE_SIZE}"
+                );
+                let response = self
+                    .client
+                    .get(url)
+                    .bearer_auth(&self.token)
+                    .send()
+                    .await
+                    .map_err(|error| format!("Failed to fetch GAIA rows: {error}"))?;
+                if response.status() == reqwest::StatusCode::UNAUTHORIZED
+                    || response.status() == reqwest::StatusCode::FORBIDDEN
+                {
+                    return Err(
+                        "GAIA access denied. Accept the dataset terms and provide a valid HF token."
+                            .into(),
+                    );
+                }
+                let status = response.status();
+                let bytes = response
+                    .bytes()
+                    .await
+                    .map_err(|error| format!("Failed to read GAIA response: {error}"))?;
+                if status.is_server_error() {
+                    eprintln!(
+                        "GAIA datasets-server returned {status}; falling back to direct parquet loading"
+                    );
+                    return self.load_tasks_from_parquet(filters).await;
+                }
+                if !status.is_success() {
+                    return Err(format!(
+                        "GAIA datasets-server returned {status}: {}",
+                        String::from_utf8_lossy(&bytes)
+                    ));
+                }
+                std::fs::write(&page_path, &bytes)
+                    .map_err(|error| format!("Failed to cache {}: {error}", page_path.display()))?;
+                bytes.to_vec()
+            };
+            let rows = parse_dataset_page(&page)?;
+            let row_count = rows.len();
+            tasks.extend(rows);
+            if row_count < PAGE_SIZE {
+                break;
+            }
+            offset += PAGE_SIZE;
+        }
+        Ok(filter_tasks(tasks, filters))
+    }
+
+    async fn load_tasks_from_parquet(
+        &self,
+        filters: &GaiaFilters,
+    ) -> Result<Vec<GaiaTask>, String> {
+        let manifest_url = format!(
+            "{DATASET_PARQUET_API_BASE}/{DATASET_ID}/parquet/{DATASET_CONFIG}/{DATASET_SPLIT}"
+        );
+        let response = self
+            .client
+            .get(&manifest_url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|error| format!("Failed to fetch GAIA parquet manifest: {error}"))?;
+        let status = response.status();
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| format!("Failed to read GAIA parquet manifest: {error}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "GAIA parquet manifest returned {status}: {}",
+                String::from_utf8_lossy(&bytes)
+            ));
+        }
+        let urls: Vec<String> = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("Invalid GAIA parquet manifest: {error}"))?;
+        if urls.is_empty() {
+            return Err("GAIA parquet manifest did not contain any files".to_string());
+        }
+
+        let parquet_dir = self.cache_dir.join("parquet");
+        std::fs::create_dir_all(&parquet_dir)
+            .map_err(|error| format!("Failed to create GAIA parquet cache: {error}"))?;
+        let mut paths = Vec::with_capacity(urls.len());
+        for (index, url) in urls.iter().enumerate() {
+            let path = parquet_dir.join(format!("{DATASET_SPLIT}-{index}.parquet"));
+            let cached = std::fs::metadata(&path).is_ok_and(|metadata| metadata.len() > 0);
+            if !cached {
+                self.download_parquet_file(url, &path).await?;
+            }
+            paths.push(path);
+        }
+
+        let tasks = tokio::task::spawn_blocking(move || parse_parquet_tasks(&paths))
+            .await
+            .map_err(|error| format!("GAIA parquet parser task failed: {error}"))??;
+        Ok(filter_tasks(tasks, filters))
+    }
+
+    async fn download_parquet_file(&self, url: &str, path: &Path) -> Result<(), String> {
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|error| format!("Failed to download GAIA parquet file: {error}"))?;
+        let status = response.status();
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| format!("Failed to read GAIA parquet file: {error}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "GAIA parquet download returned {status}: {}",
+                String::from_utf8_lossy(&bytes)
+            ));
+        }
+        if bytes.is_empty() {
+            return Err("GAIA parquet download returned an empty file".to_string());
+        }
+        std::fs::write(path, bytes)
+            .map_err(|error| format!("Failed to cache GAIA parquet file: {error}"))
+    }
+
+    pub async fn stage_attachment(
+        &self,
+        task: &GaiaTask,
+        workspace: &Path,
+    ) -> Result<Option<PathBuf>, String> {
+        let Some(file_name) = task.file_name.as_deref().filter(|name| !name.is_empty()) else {
+            return Ok(None);
+        };
+        let safe_name = Path::new(file_name)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("Invalid GAIA attachment name: {file_name}"))?;
+        let attachment_cache = self.cache_dir.join("attachments");
+        std::fs::create_dir_all(&attachment_cache)
+            .map_err(|error| format!("Failed to create attachment cache: {error}"))?;
+        let cached = attachment_cache.join(format!(
+            "{}-{safe_name}",
+            safe_cache_component(&task.task_id)?
+        ));
+        if !cached.is_file() {
+            let repo_path = task
+                .file_path
+                .as_deref()
+                .filter(|path| !path.is_empty())
+                .unwrap_or(file_name);
+            let components = safe_repo_path_components(repo_path)?;
+            let mut url = reqwest::Url::parse(&format!(
+                "https://huggingface.co/datasets/{DATASET_ID}/resolve/main/"
+            ))
+            .map_err(|error| format!("Failed to build attachment URL: {error}"))?;
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| "Failed to build attachment URL".to_string())?;
+            segments.pop_if_empty();
+            for component in components {
+                segments.push(component);
+            }
+            drop(segments);
+            let response = self
+                .client
+                .get(url)
+                .bearer_auth(&self.token)
+                .send()
+                .await
+                .map_err(|error| format!("Failed to download {safe_name}: {error}"))?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(format!("Attachment {safe_name} returned HTTP {status}"));
+            }
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|error| format!("Failed to read {safe_name}: {error}"))?;
+            std::fs::write(&cached, bytes)
+                .map_err(|error| format!("Failed to cache {safe_name}: {error}"))?;
+        }
+        let staged = workspace.join(safe_name);
+        std::fs::copy(&cached, &staged)
+            .map_err(|error| format!("Failed to stage {safe_name}: {error}"))?;
+        Ok(Some(staged))
+    }
+}
+
+fn parse_parquet_tasks(paths: &[PathBuf]) -> Result<Vec<GaiaTask>, String> {
+    let mut tasks = Vec::new();
+    for path in paths {
+        let file = File::open(path).map_err(|error| {
+            format!(
+                "Failed to open GAIA parquet file {}: {error}",
+                path.display()
+            )
+        })?;
+        let reader = SerializedFileReader::new(file).map_err(|error| {
+            format!(
+                "Failed to read GAIA parquet file {}: {error}",
+                path.display()
+            )
+        })?;
+        let rows = reader.get_row_iter(None).map_err(|error| {
+            format!(
+                "Failed to iterate GAIA parquet file {}: {error}",
+                path.display()
+            )
+        })?;
+        for row in rows {
+            let value = row
+                .map_err(|error| {
+                    format!(
+                        "Failed to decode GAIA parquet row in {}: {error}",
+                        path.display()
+                    )
+                })?
+                .to_json_value();
+            tasks.push(parse_task_row(&value)?);
+        }
+    }
+    if tasks.is_empty() {
+        return Err("GAIA parquet files did not contain any tasks".to_string());
+    }
+    Ok(tasks)
+}
+
+fn parse_dataset_page(bytes: &[u8]) -> Result<Vec<GaiaTask>, String> {
+    let payload: Value = serde_json::from_slice(bytes)
+        .map_err(|error| format!("Invalid datasets-server JSON: {error}"))?;
+    payload
+        .get("rows")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "datasets-server response has no rows array".to_string())?
+        .iter()
+        .map(|entry| parse_task_row(entry.get("row").unwrap_or(entry)))
+        .collect()
+}
+
+fn parse_task_row(row: &Value) -> Result<GaiaTask, String> {
+    let value = |names: &[&str]| {
+        names
+            .iter()
+            .find_map(|name| row.get(*name))
+            .and_then(value_as_string)
+    };
+    let task_id = value(&["task_id", "Task ID", "taskId"])
+        .ok_or_else(|| "GAIA row has no task id".to_string())?;
+    let question = value(&["Question", "question"])
+        .ok_or_else(|| format!("GAIA task {task_id} has no question"))?;
+    let gold_answer = value(&["Final answer", "final_answer", "answer"])
+        .ok_or_else(|| format!("GAIA task {task_id} has no final answer"))?;
+    let level = value(&["Level", "level"])
+        .and_then(|level| {
+            level
+                .trim_start_matches(|character: char| !character.is_ascii_digit())
+                .parse::<u8>()
+                .ok()
+        })
+        .ok_or_else(|| format!("GAIA task {task_id} has invalid level"))?;
+    let file_name = value(&["file_name", "File", "file"])
+        .filter(|name| !name.trim().is_empty())
+        .map(|name| name.trim().to_string());
+    let file_path = value(&["file_path"])
+        .filter(|path| !path.trim().is_empty())
+        .map(|path| path.trim().to_string());
+    Ok(GaiaTask {
+        task_id,
+        question,
+        level,
+        gold_answer,
+        file_name,
+        file_path,
+    })
+}
+
+fn safe_repo_path_components(path: &str) -> Result<Vec<&str>, String> {
+    let path = Path::new(path);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(format!("Invalid GAIA attachment path: {}", path.display()));
+    }
+    let components = path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    if components.is_empty() {
+        return Err("GAIA attachment path is empty".into());
+    }
+    Ok(components)
+}
+
+fn safe_cache_component(value: &str) -> Result<String, String> {
+    let component = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if component.is_empty() {
+        return Err("GAIA task id is empty".into());
+    }
+    Ok(component)
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+pub fn filter_tasks(mut tasks: Vec<GaiaTask>, filters: &GaiaFilters) -> Vec<GaiaTask> {
+    tasks.retain(|task| {
+        filters.level.is_none_or(|level| task.level == level)
+            && filters
+                .task_id
+                .as_deref()
+                .is_none_or(|task_id| task.task_id == task_id)
+    });
+    if let Some(limit) = filters.limit {
+        tasks.truncate(limit);
+    }
+    tasks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(id: &str, level: u8) -> GaiaTask {
+        GaiaTask {
+            task_id: id.into(),
+            question: "Question".into(),
+            level,
+            gold_answer: "Answer".into(),
+            file_name: None,
+            file_path: None,
+        }
+    }
+
+    #[test]
+    fn parses_datasets_server_row() {
+        let bytes = br#"{"rows":[{"row":{"task_id":"abc","Question":"Q?","Level":"2","Final answer":"42","file_name":"table.xlsx","file_path":"2023/validation/table.xlsx"}}]}"#;
+        assert_eq!(
+            parse_dataset_page(bytes).unwrap(),
+            vec![GaiaTask {
+                task_id: "abc".into(),
+                question: "Q?".into(),
+                level: 2,
+                gold_answer: "42".into(),
+                file_name: Some("table.xlsx".into()),
+                file_path: Some("2023/validation/table.xlsx".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_attachment_repo_paths() {
+        assert!(safe_repo_path_components("../secret").is_err());
+        assert!(safe_repo_path_components("/absolute/file").is_err());
+        assert_eq!(
+            safe_repo_path_components("2023/validation/table.xlsx").unwrap(),
+            vec!["2023", "validation", "table.xlsx"]
+        );
+    }
+
+    #[test]
+    fn sanitizes_task_ids_used_as_cache_components() {
+        assert_eq!(safe_cache_component("a/b:c").unwrap(), "a_b_c");
+        assert!(safe_cache_component("").is_err());
+    }
+
+    #[test]
+    fn applies_level_task_and_limit_filters() {
+        let tasks = vec![task("a", 1), task("b", 2), task("c", 2)];
+        let filtered = filter_tasks(
+            tasks,
+            &GaiaFilters {
+                level: Some(2),
+                limit: Some(1),
+                task_id: None,
+            },
+        );
+        assert_eq!(filtered, vec![task("b", 2)]);
+    }
+}

--- a/src-tauri/src/core/agent/eval/hooks.rs
+++ b/src-tauri/src/core/agent/eval/hooks.rs
@@ -1,0 +1,128 @@
+use std::path::{Component, Path, PathBuf};
+
+use async_trait::async_trait;
+
+use super::super::tools::{ApprovalHook, DesktopServices, FolderAccessHook};
+use super::super::types::{ApprovalDecision, ApprovalRequest, FolderAccessRequest};
+
+pub struct WorkspaceApproval {
+    root: PathBuf,
+}
+
+impl WorkspaceApproval {
+    pub fn new(root: &Path) -> Result<Self, String> {
+        let root = root
+            .canonicalize()
+            .map_err(|error| format!("Failed to resolve eval workspace: {error}"))?;
+        Ok(Self { root })
+    }
+
+    fn resource_is_allowed(&self, kind: &str, value: &str) -> bool {
+        if kind != "path" && kind != "file" {
+            return kind != "url" && kind != "process";
+        }
+        let path = Path::new(value);
+        if path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+        {
+            return false;
+        }
+        path.ancestors()
+            .find_map(|ancestor| ancestor.canonicalize().ok())
+            .is_some_and(|ancestor| ancestor.starts_with(&self.root))
+    }
+}
+
+#[async_trait]
+impl ApprovalHook for WorkspaceApproval {
+    async fn is_allowed(&self, _fingerprint: &str) -> bool {
+        false
+    }
+
+    async fn request(&self, request: ApprovalRequest) -> Result<ApprovalDecision, String> {
+        if !request.affected_resources.is_empty()
+            && request
+                .affected_resources
+                .iter()
+                .all(|resource| self.resource_is_allowed(&resource.kind, &resource.value))
+        {
+            Ok(ApprovalDecision::AllowOnce)
+        } else {
+            Ok(ApprovalDecision::Deny)
+        }
+    }
+}
+
+pub struct DenyFolderAccess;
+
+#[async_trait]
+impl FolderAccessHook for DenyFolderAccess {
+    async fn request(&self, _request: FolderAccessRequest) -> Result<bool, String> {
+        Ok(false)
+    }
+}
+
+pub struct HeadlessDesktop;
+
+#[async_trait]
+impl DesktopServices for HeadlessDesktop {
+    async fn write_clipboard(&self, _text: String) -> Result<(), String> {
+        Err("Clipboard is unavailable in GAIA evaluation".into())
+    }
+
+    async fn notify(&self, _title: String, _body: String) -> Result<(), String> {
+        Err("Desktop notifications are unavailable in GAIA evaluation".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent::types::ApprovalResource;
+
+    #[test]
+    fn permits_paths_inside_workspace_and_rejects_escape() {
+        let root = std::env::temp_dir().join(format!("atomic-gaia-hook-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let hook = WorkspaceApproval::new(&root).unwrap();
+        assert!(hook.resource_is_allowed("path", &root.join("new.txt").to_string_lossy()));
+        assert!(hook.resource_is_allowed("path", &root.join("new/deep/file.txt").to_string_lossy()));
+        assert!(
+            !hook.resource_is_allowed("path", &root.join("new/../../escape.txt").to_string_lossy())
+        );
+        assert!(!hook.resource_is_allowed("path", "/"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn denies_resource_free_and_outside_workspace_approvals() {
+        let root = std::env::temp_dir().join(format!("atomic-gaia-hook-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let hook = WorkspaceApproval::new(&root).unwrap();
+        let request = |affected_resources| ApprovalRequest {
+            tool: "os.shell.run".into(),
+            reason: "approval-gated".into(),
+            preview: serde_json::json!("command"),
+            affected_resources,
+            fingerprint: "fingerprint".into(),
+            can_remember: false,
+        };
+
+        assert!(matches!(
+            hook.request(request(Vec::new())).await.unwrap(),
+            ApprovalDecision::Deny
+        ));
+        assert!(matches!(
+            hook.request(request(vec![ApprovalResource {
+                kind: "path".into(),
+                value: root.join("../escape.txt").display().to_string(),
+                operation: "write".into(),
+            }]))
+            .await
+            .unwrap(),
+            ApprovalDecision::Deny
+        ));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src-tauri/src/core/agent/eval/mod.rs
+++ b/src-tauri/src/core/agent/eval/mod.rs
@@ -45,7 +45,7 @@ pub struct GaiaEvalArgs {
     mmproj: Option<PathBuf>,
     #[arg(long, env = "GAIA_HF_TOKEN")]
     hf_token: Option<String>,
-    #[arg(long, env = "GAIA_LEVEL")]
+    #[arg(long, env = "GAIA_LEVEL", default_value = "1")]
     level: Option<u8>,
     #[arg(long, env = "GAIA_LIMIT")]
     limit: Option<usize>,

--- a/src-tauri/src/core/agent/eval/mod.rs
+++ b/src-tauri/src/core/agent/eval/mod.rs
@@ -1,0 +1,516 @@
+mod dataset;
+mod hooks;
+mod report;
+mod scoring;
+mod server;
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
+use tokio_util::sync::CancellationToken;
+
+use self::dataset::{GaiaDatasetClient, GaiaFilters, GaiaTask};
+use self::hooks::{DenyFolderAccess, HeadlessDesktop, WorkspaceApproval};
+use self::report::{
+    aggregate_results, write_report, GaiaReport, GaiaTaskResult, GaiaTaskStatus, GaiaToolTrace,
+};
+use self::scoring::score_answer;
+use self::server::{DedicatedLlamaServer, LlamaServerConfig};
+use super::llm_client::{LlamaBackend, LlamaServerClient, LlamaSessionTarget};
+use super::model_profile::{detect_model_profile, AgentModelProfile};
+use super::path_policy::EditableRoots;
+use super::prompt::{
+    build_stable_prefix_for_profile, CapabilitiesSummary, SkillDescriptor,
+    DEFAULT_MAX_PARALLEL_TOOL_CALLS, ITERATION_ONE_TOOLS,
+};
+use super::runner::{run_turn, RunTurnInput};
+use super::session::AgentSessionState;
+use super::skills::{available_tool_names, SkillRegistry};
+use super::types::{AgentEvent, ToolStatus};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "gaia-eval",
+    about = "Run sequential GAIA validation evaluations"
+)]
+pub struct GaiaEvalArgs {
+    #[arg(long, env = "GAIA_LLAMA_SERVER")]
+    llama_server: PathBuf,
+    #[arg(long, env = "GAIA_MODEL")]
+    model: PathBuf,
+    #[arg(long, env = "GAIA_MMPROJ")]
+    mmproj: Option<PathBuf>,
+    #[arg(long, env = "GAIA_HF_TOKEN")]
+    hf_token: Option<String>,
+    #[arg(long, env = "GAIA_LEVEL")]
+    level: Option<u8>,
+    #[arg(long, env = "GAIA_LIMIT")]
+    limit: Option<usize>,
+    #[arg(long, env = "GAIA_TASK_ID")]
+    task_id: Option<String>,
+    #[arg(long, env = "GAIA_CONTEXT_SIZE", default_value_t = 32768)]
+    context_size: u32,
+    #[arg(long, env = "GAIA_GPU_LAYERS", default_value_t = -1)]
+    gpu_layers: i32,
+    #[arg(long, env = "GAIA_SERVER_TIMEOUT_SECS", default_value_t = 1800)]
+    server_timeout_secs: u64,
+    #[arg(long, env = "GAIA_TASK_TIMEOUT_SECS", default_value_t = 900)]
+    task_timeout_secs: u64,
+    #[arg(long, env = "GAIA_MAX_STEPS", default_value_t = 25)]
+    max_steps: u32,
+    #[arg(long, env = "GAIA_SKILLS_DIR")]
+    skills_dir: Option<PathBuf>,
+    #[arg(long, env = "GAIA_CACHE_DIR", default_value = "target/gaia-eval/cache")]
+    cache_dir: PathBuf,
+    #[arg(long, env = "GAIA_OUTPUT_DIR", default_value = "target/gaia-eval")]
+    output_dir: PathBuf,
+    #[arg(long, env = "GAIA_LLAMA_EXTRA_ARGS", value_delimiter = ' ')]
+    llama_extra_args: Vec<String>,
+}
+
+pub async fn run(args: GaiaEvalArgs) -> Result<PathBuf, String> {
+    validate_args(&args)?;
+    let started = Instant::now();
+    let timestamp = unix_millis();
+    let run_dir = args.output_dir.join("runs").join(timestamp.to_string());
+    std::fs::create_dir_all(&run_dir)
+        .map_err(|error| format!("Failed to create {}: {error}", run_dir.display()))?;
+    let token = args
+        .hf_token
+        .clone()
+        .or_else(|| std::env::var("HF_TOKEN").ok())
+        .filter(|token| !token.trim().is_empty())
+        .ok_or_else(|| "GAIA_HF_TOKEN or HF_TOKEN is required".to_string())?;
+    let dataset = GaiaDatasetClient::new(token, args.cache_dir.clone())?;
+    let filters = GaiaFilters {
+        level: args.level,
+        limit: args.limit,
+        task_id: args.task_id.clone(),
+    };
+    let tasks = dataset.load_tasks(&filters).await?;
+    if tasks.is_empty() {
+        return Err("No GAIA tasks matched the requested filters".into());
+    }
+
+    let server = DedicatedLlamaServer::start(
+        &LlamaServerConfig {
+            executable: args.llama_server.clone(),
+            model: args.model.clone(),
+            mmproj: args.mmproj.clone(),
+            context_size: args.context_size,
+            gpu_layers: args.gpu_layers,
+            startup_timeout: Duration::from_secs(args.server_timeout_secs),
+            extra_args: args.llama_extra_args.clone(),
+        },
+        &run_dir.join("server"),
+    )
+    .await?;
+    let target = LlamaSessionTarget {
+        port: i32::from(server.port()),
+        api_key: String::new(),
+        model_id: args
+            .model
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("gaia-model")
+            .to_string(),
+        has_vision: args.mmproj.is_some(),
+        backend: LlamaBackend::LlamacppUpstream,
+    };
+    let client = LlamaServerClient::new(&target).map_err(|error| error.to_string())?;
+    let cancellation = CancellationToken::new();
+    let model_profile = match client.fetch_props(&cancellation).await {
+        Ok(props) => detect_model_profile(&props),
+        Err(error) => {
+            eprintln!("Model-profile probe failed; using plain profile: {error}");
+            AgentModelProfile::Plain
+        }
+    };
+    let skill_registry = load_skills(args.skills_dir.as_deref(), &run_dir)?;
+
+    let progress = ProgressBar::new(tasks.len() as u64);
+    progress.set_style(
+        ProgressStyle::with_template(
+            "{spinner:.green} [{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}",
+        )
+        .map_err(|error| error.to_string())?
+        .progress_chars("=>-"),
+    );
+    let mut results = Vec::with_capacity(tasks.len());
+    for task in tasks {
+        progress.set_message(format!("Level {} · {}", task.level, task.task_id));
+        let result = run_task(
+            &task,
+            &dataset,
+            &run_dir,
+            &client,
+            model_profile,
+            &skill_registry,
+            args.max_steps,
+            Duration::from_secs(args.task_timeout_secs),
+        )
+        .await;
+        results.push(result);
+        progress.inc(1);
+    }
+    progress.finish_with_message("GAIA evaluation complete");
+
+    let report_path = args
+        .output_dir
+        .join(format!("gaia-report-{timestamp}.json"));
+    let report = GaiaReport {
+        dataset: "gaia-benchmark/GAIA:2023_all/validation".into(),
+        model: target.model_id,
+        generated_at_unix_ms: timestamp,
+        summary: aggregate_results(&results, started.elapsed().as_millis()),
+        tasks: results,
+    };
+    write_report(&report, &report_path)?;
+    print_summary(&report, &report_path);
+    drop(server);
+    Ok(report_path)
+}
+
+async fn run_task(
+    task: &GaiaTask,
+    dataset: &GaiaDatasetClient,
+    run_dir: &Path,
+    client: &LlamaServerClient,
+    model_profile: AgentModelProfile,
+    skill_registry: &SkillRegistry,
+    max_steps: u32,
+    timeout: Duration,
+) -> GaiaTaskResult {
+    let started = Instant::now();
+    let workspace = run_dir.join("tasks").join(safe_task_id(&task.task_id));
+    let base = || GaiaTaskResult {
+        task_id: task.task_id.clone(),
+        level: task.level,
+        question: task.question.clone(),
+        prediction: None,
+        normalized_prediction: None,
+        gold_answer: task.gold_answer.clone(),
+        correct: false,
+        status: GaiaTaskStatus::Error,
+        terminal_reason: None,
+        step_count: 0,
+        tool_trace: Vec::new(),
+        duration_ms: started.elapsed().as_millis(),
+        error: None,
+    };
+    if let Err(error) = std::fs::create_dir_all(&workspace) {
+        return task_error(base(), format!("Failed to create task workspace: {error}"));
+    }
+    let attachment = match dataset.stage_attachment(task, &workspace).await {
+        Ok(attachment) => attachment,
+        Err(error) => return task_error(base(), error),
+    };
+    let editable_roots = match EditableRoots::new(&workspace, &[]).await {
+        Ok(roots) => roots,
+        Err(error) => return task_error(base(), error),
+    };
+    let approval = match WorkspaceApproval::new(&workspace) {
+        Ok(approval) => approval,
+        Err(error) => return task_error(base(), error),
+    };
+    let session_id = format!("gaia-{}", task.task_id);
+    let run_id = format!("{session_id}-{}", uuid::Uuid::new_v4());
+    let mut session = AgentSessionState::new(&session_id);
+    let cancellation = CancellationToken::new();
+    let capabilities = CapabilitiesSummary {
+        platform: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        browser_channel: "none".into(),
+        working_dir: workspace.display().to_string(),
+        has_clipboard: false,
+        has_wmctrl: false,
+        has_notifications: false,
+    };
+    let skill_descriptors = skill_registry
+        .enabled()
+        .map(|record| SkillDescriptor {
+            name: record.manifest.name.clone(),
+            description: record.manifest.description.clone(),
+            version: record.manifest.version.clone(),
+            requires_tools: record.manifest.requires_tools.clone(),
+            requires_scripts: record.manifest.requires_scripts.clone(),
+            dangerous: record.manifest.dangerous,
+        })
+        .collect::<Vec<_>>();
+    let stable_prefix = build_stable_prefix_for_profile(
+        ITERATION_ONE_TOOLS,
+        &skill_descriptors,
+        &capabilities,
+        DEFAULT_MAX_PARALLEL_TOOL_CALLS,
+        None,
+        model_profile,
+    );
+    let attachment_instruction = attachment
+        .as_ref()
+        .and_then(|path| path.file_name())
+        .and_then(|name| name.to_str())
+        .map(|name| format!("\nThe task attachment is available at the relative path `{name}`."))
+        .unwrap_or_default();
+    let question = format!(
+        "{}{}\nReturn only the final answer required by the question, without explanation.",
+        task.question, attachment_instruction
+    );
+    let mut capture = TaskCapture::default();
+    let future = run_turn(
+        RunTurnInput {
+            run_id: &run_id,
+            session_id: &session_id,
+            user_message: &question,
+            selected_skill: None,
+            stable_prefix: &stable_prefix,
+            model_profile,
+            working_dir: &workspace,
+            editable_roots: &editable_roots,
+            external_read_only_roots: &[],
+            trusted_read_roots: &[],
+            max_steps,
+            client,
+            approval: &approval,
+            folder_access: &DenyFolderAccess,
+            desktop: &HeadlessDesktop,
+            cancellation: &cancellation,
+            session: &mut session,
+            skill_registry,
+            bundled_script_runtime: None,
+        },
+        |event| {
+            capture.observe(event);
+            Ok(())
+        },
+    );
+    let run_result = tokio::time::timeout(timeout, future).await;
+    let duration_ms = started.elapsed().as_millis();
+    match run_result {
+        Err(_) => {
+            cancellation.cancel();
+            let mut result = base();
+            result.status = GaiaTaskStatus::Timeout;
+            result.terminal_reason = Some("timeout".into());
+            result.step_count = capture.step_count;
+            result.tool_trace = capture.tool_trace;
+            result.duration_ms = duration_ms;
+            result.error = Some(format!("Task timed out after {timeout:?}"));
+            result
+        }
+        Ok(Err(error)) => {
+            let mut result = task_error(base(), error);
+            result.terminal_reason = capture.terminal_reason;
+            result.step_count = capture.step_count;
+            result.tool_trace = capture.tool_trace;
+            result.duration_ms = duration_ms;
+            result
+        }
+        Ok(Ok(())) => {
+            let Some(prediction) = capture.reply else {
+                let mut result = task_error(base(), "Agent returned no final reply".into());
+                result.terminal_reason = capture.terminal_reason;
+                result.step_count = capture.step_count;
+                result.tool_trace = capture.tool_trace;
+                result.duration_ms = duration_ms;
+                return result;
+            };
+            let correct = score_answer(&prediction, &task.gold_answer);
+            let mut result = GaiaTaskResult::prediction(
+                task.task_id.clone(),
+                task.level,
+                task.question.clone(),
+                prediction,
+                task.gold_answer.clone(),
+                correct,
+            );
+            result.terminal_reason = capture.terminal_reason;
+            result.step_count = capture.step_count;
+            result.tool_trace = capture.tool_trace;
+            result.duration_ms = duration_ms;
+            result.error = capture.error;
+            result
+        }
+    }
+}
+
+#[derive(Default)]
+struct TaskCapture {
+    reply: Option<String>,
+    terminal_reason: Option<String>,
+    step_count: u32,
+    tool_trace: Vec<GaiaToolTrace>,
+    error: Option<String>,
+}
+
+impl TaskCapture {
+    fn observe(&mut self, event: AgentEvent) {
+        match event {
+            AgentEvent::StepStarted { step_index } => {
+                self.step_count = self.step_count.max(step_index + 1);
+            }
+            AgentEvent::AssistantReply { text } => self.reply = Some(text),
+            AgentEvent::ToolCallExecuted { result } => self.tool_trace.push(GaiaToolTrace {
+                tool: result.call.tool,
+                args: result.call.args,
+                status: match result.outcome.status {
+                    ToolStatus::Ok => "ok",
+                    ToolStatus::Error => "error",
+                    ToolStatus::Denied => "denied",
+                    ToolStatus::Cancelled => "cancelled",
+                }
+                .into(),
+                summary: result.outcome.summary,
+                details: result.outcome.details,
+            }),
+            AgentEvent::StepError { message, category } => {
+                self.error = Some(format!("{category}: {message}"));
+            }
+            AgentEvent::TurnFinished { reason, step_count } => {
+                self.terminal_reason = Some(reason);
+                self.step_count = step_count;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn load_skills(skills_dir: Option<&Path>, run_dir: &Path) -> Result<SkillRegistry, String> {
+    let root = skills_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| run_dir.join("skills"));
+    SkillRegistry::load(root, &BTreeSet::new(), &available_tool_names())
+}
+
+fn task_error(mut result: GaiaTaskResult, error: String) -> GaiaTaskResult {
+    result.error = Some(error);
+    result
+}
+
+fn validate_args(args: &GaiaEvalArgs) -> Result<(), String> {
+    if !args.llama_server.is_file() {
+        return Err(format!(
+            "GAIA_LLAMA_SERVER is not a file: {}",
+            args.llama_server.display()
+        ));
+    }
+    if !args.model.is_file() {
+        return Err(format!(
+            "GAIA_MODEL is not a file: {}",
+            args.model.display()
+        ));
+    }
+    if args.level.is_some_and(|level| !(1..=3).contains(&level)) {
+        return Err("GAIA_LEVEL must be 1, 2, or 3".into());
+    }
+    if args.limit == Some(0) {
+        return Err("GAIA_LIMIT must be greater than zero".into());
+    }
+    Ok(())
+}
+
+fn print_summary(report: &GaiaReport, path: &Path) {
+    println!("\nGAIA validation results");
+    println!(
+        "Overall: {:.2}% ({}/{})",
+        report.summary.accuracy * 100.0,
+        report.summary.correct,
+        report.summary.total
+    );
+    for level in 1..=3 {
+        let summary = report
+            .summary
+            .by_level
+            .get(&level)
+            .cloned()
+            .unwrap_or_default();
+        println!(
+            "Level {level}: {:.2}% ({}/{})",
+            summary.accuracy * 100.0,
+            summary.correct,
+            summary.total
+        );
+    }
+    println!(
+        "correct={} incorrect={} error={} timeout={}",
+        report.summary.correct,
+        report.summary.incorrect,
+        report.summary.error,
+        report.summary.timeout
+    );
+    println!("elapsed={:.1}s", report.summary.elapsed_ms as f64 / 1000.0);
+    println!("report={}", path.display());
+}
+
+fn safe_task_id(task_id: &str) -> String {
+    task_id
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn unix_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent::types::{ToolCallPayload, ToolExecution, ToolOutcome};
+
+    #[test]
+    fn task_capture_records_reply_tools_errors_and_terminal_state() {
+        let mut capture = TaskCapture::default();
+        capture.observe(AgentEvent::StepStarted { step_index: 1 });
+        capture.observe(AgentEvent::ToolCallExecuted {
+            result: ToolExecution {
+                call: ToolCallPayload {
+                    tool: "os.fs.read".into(),
+                    args: serde_json::json!({ "path": "input.txt" }),
+                },
+                outcome: ToolOutcome {
+                    status: ToolStatus::Ok,
+                    summary: "read input.txt".into(),
+                    details: Some(serde_json::json!({ "bytes": 10 })),
+                },
+                batch_index: 0,
+                batch_size: 1,
+            },
+        });
+        capture.observe(AgentEvent::AssistantReply { text: "42".into() });
+        capture.observe(AgentEvent::StepError {
+            message: "repair attempted".into(),
+            category: "grammar".into(),
+        });
+        capture.observe(AgentEvent::TurnFinished {
+            reason: "reply".into(),
+            step_count: 2,
+        });
+
+        assert_eq!(capture.reply.as_deref(), Some("42"));
+        assert_eq!(capture.tool_trace.len(), 1);
+        assert_eq!(capture.tool_trace[0].tool, "os.fs.read");
+        assert_eq!(
+            capture.tool_trace[0].args,
+            serde_json::json!({ "path": "input.txt" })
+        );
+        assert_eq!(
+            capture.tool_trace[0].details,
+            Some(serde_json::json!({ "bytes": 10 }))
+        );
+        assert_eq!(capture.error.as_deref(), Some("grammar: repair attempted"));
+        assert_eq!(capture.terminal_reason.as_deref(), Some("reply"));
+        assert_eq!(capture.step_count, 2);
+    }
+}

--- a/src-tauri/src/core/agent/eval/report.rs
+++ b/src-tauri/src/core/agent/eval/report.rs
@@ -1,0 +1,180 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::scoring::normalize_answer;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GaiaToolTrace {
+    pub tool: String,
+    pub args: serde_json::Value,
+    pub status: String,
+    pub summary: String,
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GaiaTaskStatus {
+    Correct,
+    Incorrect,
+    Error,
+    Timeout,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GaiaTaskResult {
+    pub task_id: String,
+    pub level: u8,
+    pub question: String,
+    pub prediction: Option<String>,
+    pub normalized_prediction: Option<String>,
+    pub gold_answer: String,
+    pub correct: bool,
+    pub status: GaiaTaskStatus,
+    pub terminal_reason: Option<String>,
+    pub step_count: u32,
+    pub tool_trace: Vec<GaiaToolTrace>,
+    pub duration_ms: u128,
+    pub error: Option<String>,
+}
+
+impl GaiaTaskResult {
+    pub fn prediction(
+        task_id: String,
+        level: u8,
+        question: String,
+        prediction: String,
+        gold_answer: String,
+        correct: bool,
+    ) -> Self {
+        Self {
+            task_id,
+            level,
+            question,
+            normalized_prediction: Some(normalize_answer(&prediction)),
+            prediction: Some(prediction),
+            gold_answer,
+            correct,
+            status: if correct {
+                GaiaTaskStatus::Correct
+            } else {
+                GaiaTaskStatus::Incorrect
+            },
+            terminal_reason: None,
+            step_count: 0,
+            tool_trace: Vec::new(),
+            duration_ms: 0,
+            error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GaiaLevelSummary {
+    pub total: usize,
+    pub correct: usize,
+    pub accuracy: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GaiaSummary {
+    pub total: usize,
+    pub correct: usize,
+    pub incorrect: usize,
+    pub error: usize,
+    pub timeout: usize,
+    pub accuracy: f64,
+    pub by_level: BTreeMap<u8, GaiaLevelSummary>,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GaiaReport {
+    pub dataset: String,
+    pub model: String,
+    pub generated_at_unix_ms: u128,
+    pub summary: GaiaSummary,
+    pub tasks: Vec<GaiaTaskResult>,
+}
+
+pub fn aggregate_results(results: &[GaiaTaskResult], elapsed_ms: u128) -> GaiaSummary {
+    let mut summary = GaiaSummary {
+        total: results.len(),
+        correct: 0,
+        incorrect: 0,
+        error: 0,
+        timeout: 0,
+        accuracy: 0.0,
+        by_level: BTreeMap::new(),
+        elapsed_ms,
+    };
+    for result in results {
+        let level = summary.by_level.entry(result.level).or_default();
+        level.total += 1;
+        match result.status {
+            GaiaTaskStatus::Correct => {
+                summary.correct += 1;
+                level.correct += 1;
+            }
+            GaiaTaskStatus::Incorrect => summary.incorrect += 1,
+            GaiaTaskStatus::Error => summary.error += 1,
+            GaiaTaskStatus::Timeout => summary.timeout += 1,
+        }
+    }
+    summary.accuracy = accuracy(summary.correct, summary.total);
+    for level in summary.by_level.values_mut() {
+        level.accuracy = accuracy(level.correct, level.total);
+    }
+    summary
+}
+
+pub fn write_report(report: &GaiaReport, path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create report directory: {error}"))?;
+    }
+    let json = serde_json::to_vec_pretty(report)
+        .map_err(|error| format!("Failed to serialize GAIA report: {error}"))?;
+    std::fs::write(path, json)
+        .map_err(|error| format!("Failed to write {}: {error}", path.display()))
+}
+
+fn accuracy(correct: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        correct as f64 / total as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aggregates_statuses_and_levels() {
+        let correct =
+            GaiaTaskResult::prediction("a".into(), 1, "Q".into(), "A".into(), "A".into(), true);
+        let incorrect =
+            GaiaTaskResult::prediction("b".into(), 2, "Q".into(), "B".into(), "A".into(), false);
+        let mut error = incorrect.clone();
+        error.task_id = "c".into();
+        error.level = 3;
+        error.status = GaiaTaskStatus::Error;
+        let mut timeout = incorrect.clone();
+        timeout.task_id = "d".into();
+        timeout.status = GaiaTaskStatus::Timeout;
+        let summary = aggregate_results(&[correct, incorrect, error, timeout], 10);
+        assert_eq!(summary.total, 4);
+        assert_eq!(summary.correct, 1);
+        assert_eq!(summary.incorrect, 1);
+        assert_eq!(summary.error, 1);
+        assert_eq!(summary.timeout, 1);
+        assert_eq!(summary.elapsed_ms, 10);
+        assert_eq!(summary.by_level[&1].accuracy, 1.0);
+        assert_eq!(summary.by_level[&2].accuracy, 0.0);
+        assert_eq!(summary.by_level[&3].accuracy, 0.0);
+    }
+}

--- a/src-tauri/src/core/agent/eval/scoring.rs
+++ b/src-tauri/src/core/agent/eval/scoring.rs
@@ -1,0 +1,89 @@
+pub fn score_answer(prediction: &str, gold: &str) -> bool {
+    if let Some(gold_number) = normalize_number(gold) {
+        return normalize_number(prediction).is_some_and(|prediction| prediction == gold_number);
+    }
+    if gold.contains(',') || gold.contains(';') {
+        let prediction_items = split_list(prediction);
+        let gold_items = split_list(gold);
+        if prediction_items.len() != gold_items.len() {
+            return false;
+        }
+        return prediction_items
+            .into_iter()
+            .zip(gold_items)
+            .all(|(prediction_item, gold_item)| {
+                if let Some(gold_number) = normalize_number(gold_item) {
+                    normalize_number(prediction_item)
+                        .is_some_and(|prediction| prediction == gold_number)
+                } else {
+                    normalize_string(prediction_item, false) == normalize_string(gold_item, false)
+                }
+            });
+    }
+    normalize_answer(prediction) == normalize_answer(gold)
+}
+
+pub fn normalize_answer(value: &str) -> String {
+    normalize_string(value, true)
+}
+
+fn normalize_string(value: &str, remove_punctuation: bool) -> String {
+    value
+        .trim()
+        .to_lowercase()
+        .chars()
+        .filter(|character| {
+            !character.is_whitespace() && (!remove_punctuation || !character.is_ascii_punctuation())
+        })
+        .collect()
+}
+
+fn normalize_number(value: &str) -> Option<f64> {
+    value
+        .replace(['$', '%', ','], "")
+        .trim()
+        .parse::<f64>()
+        .ok()
+}
+
+fn split_list(value: &str) -> Vec<&str> {
+    value.split([',', ';']).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scores_numbers_with_grouping_and_decimal_equivalence() {
+        assert!(score_answer("1,234.00", "1234"));
+        assert!(score_answer("1234", "$1,234"));
+        assert!(score_answer("50", "50%"));
+        assert!(score_answer("-0.0", "0"));
+    }
+
+    #[test]
+    fn scores_strings_without_case_space_or_punctuation() {
+        assert!(score_answer(" New York! ", "new york"));
+    }
+
+    #[test]
+    fn scores_lists_in_order_with_number_aware_elements() {
+        assert!(score_answer("Paris; London", "paris, london"));
+        assert!(score_answer("$1, 2%", "1;2"));
+        assert!(score_answer("1; 2", "$1; 2%"));
+        assert!(!score_answer("London, Paris", "paris, london"));
+    }
+
+    #[test]
+    fn preserves_punctuation_when_scoring_list_elements() {
+        assert!(score_answer("A.; B", "a.;b"));
+        assert!(!score_answer("A; B", "a.;b"));
+    }
+
+    #[test]
+    fn rejects_wrong_answers() {
+        assert!(!score_answer("41", "42"));
+        assert!(!score_answer("A, B", "A, C"));
+    }
+}

--- a/src-tauri/src/core/agent/eval/server.rs
+++ b/src-tauri/src/core/agent/eval/server.rs
@@ -1,0 +1,164 @@
+use std::fs::File;
+use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct LlamaServerConfig {
+    pub executable: PathBuf,
+    pub model: PathBuf,
+    pub mmproj: Option<PathBuf>,
+    pub context_size: u32,
+    pub gpu_layers: i32,
+    pub startup_timeout: Duration,
+    pub extra_args: Vec<String>,
+}
+
+pub struct DedicatedLlamaServer {
+    child: Child,
+    port: u16,
+    stdout_log: PathBuf,
+    stderr_log: PathBuf,
+}
+
+impl DedicatedLlamaServer {
+    pub async fn start(config: &LlamaServerConfig, log_dir: &Path) -> Result<Self, String> {
+        validate_config(config)?;
+        std::fs::create_dir_all(log_dir)
+            .map_err(|error| format!("Failed to create server log directory: {error}"))?;
+        let port = reserve_loopback_port()?;
+        let stdout_log = log_dir.join("llama-server.stdout.log");
+        let stderr_log = log_dir.join("llama-server.stderr.log");
+        let stdout = File::create(&stdout_log)
+            .map_err(|error| format!("Failed to create llama-server stdout log: {error}"))?;
+        let stderr = File::create(&stderr_log)
+            .map_err(|error| format!("Failed to create llama-server stderr log: {error}"))?;
+        let mut command = Command::new(&config.executable);
+        command.args([
+            "--model",
+            &config.model.to_string_lossy(),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port.to_string(),
+            "--parallel",
+            "1",
+            "--ctx-size",
+            &config.context_size.to_string(),
+            "--no-webui",
+            "--jinja",
+            "-ngl",
+            &config.gpu_layers.to_string(),
+        ]);
+        if let Some(mmproj) = &config.mmproj {
+            command.args(["--mmproj", &mmproj.to_string_lossy()]);
+        }
+        command
+            .args(&config.extra_args)
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr));
+        let child = command.spawn().map_err(|error| {
+            format!(
+                "Failed to start llama-server at {}: {error}",
+                config.executable.display()
+            )
+        })?;
+        let mut server = Self {
+            child,
+            port,
+            stdout_log,
+            stderr_log,
+        };
+        if let Err(error) = server.wait_for_health(config.startup_timeout).await {
+            return Err(format!("{error}\n{}", server.diagnostics()));
+        }
+        Ok(server)
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn diagnostics(&mut self) -> String {
+        let status = self.child.try_wait().ok().flatten();
+        format!(
+            "process_status={status:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            read_log_tail(&self.stdout_log),
+            read_log_tail(&self.stderr_log)
+        )
+    }
+
+    async fn wait_for_health(&mut self, timeout: Duration) -> Result<(), String> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .map_err(|error| format!("Failed to build health client: {error}"))?;
+        let health_url = format!("http://127.0.0.1:{}/health", self.port);
+        let started = Instant::now();
+        loop {
+            if let Some(status) = self.child.try_wait().map_err(|error| error.to_string())? {
+                return Err(format!("llama-server exited before readiness: {status}"));
+            }
+            if let Ok(response) = client.get(&health_url).send().await {
+                if response.status().is_success() {
+                    return Ok(());
+                }
+            }
+            if started.elapsed() >= timeout {
+                return Err(format!(
+                    "llama-server health check timed out after {timeout:?}"
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+}
+
+impl Drop for DedicatedLlamaServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn validate_config(config: &LlamaServerConfig) -> Result<(), String> {
+    if !config.executable.is_file() {
+        return Err(format!(
+            "llama-server is not a file: {}",
+            config.executable.display()
+        ));
+    }
+    if !config.model.is_file() {
+        return Err(format!(
+            "GGUF model is not a file: {}",
+            config.model.display()
+        ));
+    }
+    if let Some(mmproj) = &config.mmproj {
+        if !mmproj.is_file() {
+            return Err(format!("mmproj is not a file: {}", mmproj.display()));
+        }
+    }
+    Ok(())
+}
+
+fn reserve_loopback_port() -> Result<u16, String> {
+    let listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .map_err(|error| format!("Failed to reserve loopback port: {error}"))?;
+    listener
+        .local_addr()
+        .map(|address| address.port())
+        .map_err(|error| format!("Failed to read reserved loopback port: {error}"))
+}
+
+fn read_log_tail(path: &Path) -> String {
+    const MAX_LOG_CHARS: usize = 20_000;
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return "<unavailable>".into();
+    };
+    let chars = content.chars().collect::<Vec<_>>();
+    chars[chars.len().saturating_sub(MAX_LOG_CHARS)..]
+        .iter()
+        .collect()
+}

--- a/src-tauri/src/core/agent/mod.rs
+++ b/src-tauri/src/core/agent/mod.rs
@@ -19,6 +19,8 @@ pub mod attachments;
 mod batch_executor;
 pub mod commands;
 pub mod compressor;
+#[cfg(feature = "gaia-eval")]
+pub mod eval;
 pub mod folder_access;
 pub mod grammar;
 pub mod llm_client;


### PR DESCRIPTION
This commit introduces a new feature-gated `gaia-eval` binary for evaluating the Rust Agent in a controlled environment. It allows for sequential evaluation of local models without reliance on the Tauri UI or IPC, facilitating reproducible benchmarks. The `Makefile` is updated to include a `gaia-eval` target, and the `Cargo.toml` is modified to add necessary dependencies. Additionally, the `AGENTS.md` documentation is updated to reflect this new functionality and its implications for model comparison and execution management.

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
