### PR TITLE
fix: basenameNoExt returns empty string for files without extension

### DIFF
--- a/web-app/src/lib/__tests__/utils.test.ts
+++ b/web-app/src/lib/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   formatMegaBytes,
   formatDuration,
   getModelDisplayName,
+  basenameNoExt,
   withTimeout,
   OPERATION_TIMED_OUT_CODE,
 } from '../utils'
@@ -252,6 +253,31 @@ describe('getModelDisplayName', () => {
       displayName: 'Model (Version 2.0) - Fine-tuned',
     } as Model
     expect(getModelDisplayName(model)).toBe('Model (Version 2.0) - Fine-tuned')
+  })
+})
+
+describe('basenameNoExt', () => {
+  it('removes a single extension', () => {
+    expect(basenameNoExt('model.gguf')).toBe('model')
+  })
+
+  it('removes compound extensions like .tar.gz', () => {
+    expect(basenameNoExt('backend.tar.gz')).toBe('backend')
+    expect(basenameNoExt('backend.TAR.GZ')).toBe('backend')
+  })
+
+  it('removes .zip extension', () => {
+    expect(basenameNoExt('backend.zip')).toBe('backend')
+  })
+
+  it('returns the name unchanged for files without an extension', () => {
+    expect(basenameNoExt('README')).toBe('README')
+    expect(basenameNoExt('Makefile')).toBe('Makefile')
+  })
+
+  it('handles paths with directory components', () => {
+    expect(basenameNoExt('/path/to/model.gguf')).toBe('model')
+    expect(basenameNoExt('/path/to/README')).toBe('README')
   })
 })
 

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -23,7 +23,11 @@ export function basenameNoExt(filePath: string): string {
   }
 
   // fallback: remove only the last extension
-  return base.slice(0, -path.extname(base).length)
+  const ext = path.extname(base)
+  if (ext) {
+    return base.slice(0, -ext.length)
+  }
+  return base
 }
 
 /**


### PR DESCRIPTION
basenameNoExt called path.extname(base) which returns '' for files without an extension. slice(0, -0) evaluates to slice(0, 0), returning an empty string instead of the original name.

Fix: guard with an ext truthiness check before slicing, consistent with the extension's own basenameNoExt implementation.

Added test cases for no-extension files and path-with-directory inputs.