### PR TITLE
fix: handleDownloadStarted silently drops download state when completed auto-dismiss fires

### DIFF
--- a/web-app/src/hooks/__tests__/useBackendUpdater.test.ts
+++ b/web-app/src/hooks/__tests__/useBackendUpdater.test.ts
@@ -277,6 +277,36 @@ describe('useBackendUpdater', () => {
 
       expect(result.current.recommendationPhase).toBe('restart-required')
     })
+
+    it('clears the completed auto-dismiss timer when a download starts mid-success', () => {
+      vi.useFakeTimers()
+      const { result } = renderHook(() => useBackendUpdater())
+      detect()
+
+      // Complete the download and hot-swap successfully
+      finishDownload('completed')
+      act(() => {
+        window.dispatchEvent(new Event(HOTSWAPPED_EVENT))
+      })
+      expect(result.current.recommendationPhase).toBe('completed')
+
+      // Start a new download while in 'completed' state (within auto-dismiss window)
+      act(() => {
+        events.emit('onBackendDownloadStarted', {
+          backend: RECOMMENDED,
+          status: 'downloading',
+        })
+      })
+      expect(result.current.recommendationPhase).toBe('downloading')
+
+      // Advance past the completed auto-dismiss window.
+      // Without the fix, the stale completed timeout fires and resets
+      // the phase to 'idle', losing the 'downloading' state.
+      act(() => {
+        vi.advanceTimersByTime(1500)
+      })
+      expect(result.current.recommendationPhase).toBe('downloading')
+    })
   })
 
   /// Both llama providers ship side by side on Windows/Linux and can be

--- a/web-app/src/hooks/useBackendUpdater.ts
+++ b/web-app/src/hooks/useBackendUpdater.ts
@@ -294,25 +294,27 @@ export const useBackendUpdater = (config: UseBackendUpdaterConfig = {}) => {
   // match to drive the phase transitions from events alone, regardless
   // of which component initiated the download.
   useEffect(() => {
-    const handleDownloadStarted = (payload: {
-      backend: string
-      status: string
-      provider?: string
-    }) => {
-      if (!isOurEvent(payload)) return
-      setDownloadState({
-        isDownloading: true,
-        backendName: payload.backend,
-        status: 'downloading',
-      })
-      if (
-        recommendation &&
-        payload.backend === recommendation.recommendedBackend &&
-        recommendationPhase !== 'restart-required'
-      ) {
-        setRecommendationPhase('downloading')
-      }
-    }
+     const handleDownloadStarted = (payload: {
+       backend: string
+       status: string
+       provider?: string
+     }) => {
+       if (!isOurEvent(payload)) return
+       setDownloadState({
+         isDownloading: true,
+         backendName: payload.backend,
+         status: 'downloading',
+       })
+       if (
+         recommendation &&
+         payload.backend === recommendation.recommendedBackend &&
+         recommendationPhase !== 'restart-required'
+       ) {
+         clearHotswapTimeout()
+         clearCompletedTimeout()
+         setRecommendationPhase('downloading')
+       }
+     }
 
     const handleDownloadFinished = (payload: {
       backend: string

--- a/web-app/src/hooks/useBackendUpdater.ts
+++ b/web-app/src/hooks/useBackendUpdater.ts
@@ -294,27 +294,27 @@ export const useBackendUpdater = (config: UseBackendUpdaterConfig = {}) => {
   // match to drive the phase transitions from events alone, regardless
   // of which component initiated the download.
   useEffect(() => {
-     const handleDownloadStarted = (payload: {
-       backend: string
-       status: string
-       provider?: string
-     }) => {
-       if (!isOurEvent(payload)) return
-       setDownloadState({
-         isDownloading: true,
-         backendName: payload.backend,
-         status: 'downloading',
-       })
-       if (
-         recommendation &&
-         payload.backend === recommendation.recommendedBackend &&
-         recommendationPhase !== 'restart-required'
-       ) {
-         clearHotswapTimeout()
-         clearCompletedTimeout()
-         setRecommendationPhase('downloading')
-       }
-     }
+    const handleDownloadStarted = (payload: {
+      backend: string
+      status: string
+      provider?: string
+    }) => {
+      if (!isOurEvent(payload)) return
+      setDownloadState({
+        isDownloading: true,
+        backendName: payload.backend,
+        status: 'downloading',
+      })
+      if (
+        recommendation &&
+        payload.backend === recommendation.recommendedBackend &&
+        recommendationPhase !== 'restart-required'
+      ) {
+        clearHotswapTimeout()
+        clearCompletedTimeout()
+        setRecommendationPhase('downloading')
+      }
+    }
 
     const handleDownloadFinished = (payload: {
       backend: string
@@ -363,7 +363,7 @@ export const useBackendUpdater = (config: UseBackendUpdaterConfig = {}) => {
       events.off(AppEvent.onBackendDownloadStarted, handleDownloadStarted)
       events.off(AppEvent.onBackendDownloadFinished, handleDownloadFinished)
     }
-  }, [recommendationPhase, recommendation, clearHotswapTimeout, isOurEvent])
+  }, [recommendationPhase, recommendation, clearHotswapTimeout, clearCompletedTimeout, isOurEvent])
 
   // Listen for the live hot-swap completion event dispatched by
   // `applyBackendLive()` in the llamacpp extension. The event arrives on


### PR DESCRIPTION
When a download started while the recommendation phase was 'completed' (within the 1500ms auto-dismiss window), handleDownloadStarted transitioned the phase to 'downloading' but left the completedTimeoutRef armed. When that timer later fired, it unconditionally called setRecommendation(null) and setRecommendationPhase('idle'), wiping out the in-progress download state.

handleManualDownloading already calls clearHotswapTimeout() and clearCompletedTimeout() before transitioning; handleDownloadStarted was missing the same cleanup. Add the two clear calls so stale timeouts can never overwrite a fresh download phase.

Added test: 'clears the completed auto-dismiss timer when a download starts mid-success'.