### PR TITLE
fix: honor zero progress values in useDownloadStore.updateProgress

### DIFF
--- a/web-app/src/hooks/__tests__/useDownloadStore.test.ts
+++ b/web-app/src/hooks/__tests__/useDownloadStore.test.ts
@@ -93,6 +93,28 @@ describe('useDownloadStore', () => {
         total: 0,
       })
     })
+
+    it('should honor explicit zero current/total after a non-zero value', () => {
+      const { result } = renderHook(() => useDownloadStore())
+
+      // A download in progress reports a non-zero byte count.
+      act(() => {
+        result.current.updateProgress('test-id', 50, 'test-model', 500, 1000)
+      })
+
+      // A restarted/resumed transfer resets the counters to 0 — the store
+      // must not keep the stale 500/1000 from the previous transfer.
+      act(() => {
+        result.current.updateProgress('test-id', 0, 'test-model', 0, 0)
+      })
+
+      expect(result.current.downloads['test-id']).toEqual({
+        name: 'test-model',
+        progress: 0,
+        current: 0,
+        total: 0,
+      })
+    })
   })
 
   describe('removeDownload', () => {

--- a/web-app/src/hooks/useDownloadStore.ts
+++ b/web-app/src/hooks/useDownloadStore.ts
@@ -85,10 +85,13 @@ export const useDownloadStore = create<DownloadState>((set) => ({
         ...state.downloads,
         [id]: {
           ...state.downloads[id],
-          name: name || state.downloads[id]?.name || '',
+          // `??` (not `||`) so explicit zero values — e.g. a restarted or
+          // resumed transfer whose byte counter resets to 0 — are honored
+          // instead of being replaced by the stale previous value.
+          name: name ?? state.downloads[id]?.name ?? '',
           progress,
-          current: current || state.downloads[id]?.current || 0,
-          total: total || state.downloads[id]?.total || 0,
+          current: current ?? state.downloads[id]?.current ?? 0,
+          total: total ?? state.downloads[id]?.total ?? 0,
         },
       },
     })),


### PR DESCRIPTION
## What

`useDownloadStore.updateProgress` merged `name`/`current`/`total` with `||`, so an explicit `0` (current bytes / total bytes) arriving **after** a non-zero value was silently replaced by the stale previous value:

- On download **restart or resume** the transfer byte counter resets to `0`, but the UI kept showing the previous transfer's `current`/`total` until the new transfer caught up — a wrong progress bar the whole time.
- The store deliberately keeps paused download entries (ATO-154), so a stale `downloads[id]` is a realistic precondition.

## Fix

Switch the three merges from `||` to `??` so explicit zeros are stored. The existing fallback for `undefined` args is unchanged (verified by the existing 'preserve existing values' and 'default values' tests).

## Verification

- New regression test: non-zero `500/1000` then `0/0` now stores `0/0`.
- `useDownloadStore.test.ts` 19/19 pass, `tsc -b` clean, `eslint` 0 errors.
