### PR TITLE
fix: import ServiceHub type from @/services in provider-api-key

### DIFF
--- a/web-app/src/lib/provider-api-key.ts
+++ b/web-app/src/lib/provider-api-key.ts
@@ -16,7 +16,7 @@
  */
 
 import { captureProviderKeyConfigured } from '@/lib/onboarding-telemetry'
-import type { ServiceHub } from '@/hooks/useServiceHub'
+import type { ServiceHub } from '@/services'
 
 /**
  * Copy of `settings` with the `api-key` entry's value replaced.


### PR DESCRIPTION
The `v2.0.18` release build ([run 32264635941](https://github.com/AtomicBot-ai/Atomic-Chat/actions/runs/32264635941)) failed on `yarn build:web` with:

```
src/lib/provider-api-key.ts(19,15): error TS2724: '"@/hooks/useServiceHub"' has no exported member named 'ServiceHub'.
```

The `ServiceHub` type is declared in `@/services`; `useServiceHub.ts` imports it but does not re-export it. This fixes the import. `tsc --noEmit` is clean after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)