### PR TITLE
fix(chat): bound streaming reasoning render cost

### DIFF
--- a/docs/decisions/2026-09-04-bound-streaming-reasoning-render-cost.md
+++ b/docs/decisions/2026-09-04-bound-streaming-reasoning-render-cost.md
@@ -5,19 +5,39 @@ title: 'Bound streaming reasoning render cost'
 
 # 2026-09-04 — Bound streaming reasoning render cost
 
-- **Context:** A self-hosted model streamed roughly 9,500–12,000 reasoning
-  tokens at about 76 tokens/s. The macOS WebKit content process then saturated
-  a CPU core and the UI stopped responding. Every delta reparsed and animated
-  the complete growing reasoning string through Streamdown, while the
-  reasoning view also forced an unthrottled scroll layout.
-- **Decision:** While reasoning streams, render only its most recent 16,000
-  characters as plain text. Parse the complete Markdown once after completion,
-  without animation. Coalesce auto-scroll to one animation-frame update and
-  change tail-follow state only in response to actual panel scroll events.
-- **Consequences:** Streaming render and layout cost remain bounded while the
-  completed reasoning stays intact and formatted. Earlier live reasoning is
-  hidden only until generation finishes. Automatic tail-following remains
-  responsive, and readers may still pause it by scrolling upward.
+- **Context:** Long reasoning traces saturated the macOS WebKit content
+  process and the app stopped responding after two to three minutes of
+  thinking — with a self-hosted model and with a remote one alike, so the cost
+  is in the renderer, not in inference. Every delta re-ran
+  `parseIncompleteMarkdown` and the block lexer over the whole growing trace,
+  and the reasoning view forced an unthrottled scroll layout on top. Cost of a
+  single streamed delta measured in WebKit, by trace length: 3ms at 2k
+  characters, 42ms at 20k, 147ms at 40k, 314ms at 60k, 549ms at 80k. The
+  growth is superlinear, so the frame budget is gone within the first minute
+  and by minute three a single token costs half a second.
+- **Decision:** While reasoning streams, render only its most recent 4,000
+  characters as plain text — the panel is 128px tall while a turn runs, so the
+  window only covers scroll-back. Parse the complete Markdown once, and only
+  while a reader actually has the panel open. Coalesce auto-scroll to one
+  animation-frame update, and change tail-follow state only in response to a
+  scroll the reader performed: a programmatic tail scroll emits `scroll` too,
+  delivered a frame later once the next chunk has already grown
+  `scrollHeight`, and measuring the distance then ends tail-following for the
+  rest of the turn.
+- **Consequences:** Streaming render and layout cost are constant instead of
+  superlinear in trace length: ~1ms per delta at any length, against 314ms at
+  60k characters. The completed reasoning stays intact and formatted. Earlier
+  live reasoning is hidden until generation finishes. The panel auto-closes
+  when a turn ends, so the full parse — 657ms on an 80k-character trace — no
+  longer runs for a subtree that is discarded on the next commit.
+- **Not covered:** the answer body takes the same path with a heavier plugin
+  set (gfm, math, katex, harden, code, mermaid, cjk), measured at 41ms per
+  delta on a 20k-character answer and 317ms at 60k, so a long enough answer
+  still reaches the same wall. Plain text is not an option there. Chat updates
+  are throttled from 16ms to 50ms, which divides the cost and keeps
+  mid-length answers inside budget; making it independent of answer length
+  needs the stable prefix to stop being re-parsed, which is a change inside
+  the Markdown renderer.
 - **Owner:** team.
 - **Links:**
   [`web-app/src/components/ai-elements/reasoning.tsx`](../../web-app/src/components/ai-elements/reasoning.tsx),

--- a/docs/decisions/2026-09-04-bound-streaming-reasoning-render-cost.md
+++ b/docs/decisions/2026-09-04-bound-streaming-reasoning-render-cost.md
@@ -1,0 +1,25 @@
+---
+date: 2026-09-04
+title: 'Bound streaming reasoning render cost'
+---
+
+# 2026-09-04 — Bound streaming reasoning render cost
+
+- **Context:** A self-hosted model streamed roughly 9,500–12,000 reasoning
+  tokens at about 76 tokens/s. The macOS WebKit content process then saturated
+  a CPU core and the UI stopped responding. Every delta reparsed and animated
+  the complete growing reasoning string through Streamdown, while the
+  reasoning view also forced an unthrottled scroll layout.
+- **Decision:** While reasoning streams, render only its most recent 16,000
+  characters as plain text. Parse the complete Markdown once after completion,
+  without animation. Coalesce auto-scroll to one animation-frame update and
+  change tail-follow state only in response to actual panel scroll events.
+- **Consequences:** Streaming render and layout cost remain bounded while the
+  completed reasoning stays intact and formatted. Earlier live reasoning is
+  hidden only until generation finishes. Automatic tail-following remains
+  responsive, and readers may still pause it by scrolling upward.
+- **Owner:** team.
+- **Links:**
+  [`web-app/src/components/ai-elements/reasoning.tsx`](../../web-app/src/components/ai-elements/reasoning.tsx),
+  [`web-app/src/hooks/useReasoningAutoScroll.ts`](../../web-app/src/hooks/useReasoningAutoScroll.ts),
+  [`web-app/src/routes/threads/$threadId.tsx`](../../web-app/src/routes/threads/$threadId.tsx).

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -248,8 +248,9 @@ decision is reversed, add a new one that says which record it supersedes.
 - **2026-05-22** — [Pin static WiX `upgradeCode` to legacy Jan UUID for in-place MSI upgrades](2026-05-22-pin-static-wix-upgradecode-to-legacy-jan-uuid-for-in-place-msi.md)
 - **2026-05-19** — [Product identity is "Atomic Chat"; new code stops carrying Jan branding](2026-05-19-product-identity-is-atomic-chat-new-code-stops-carrying-jan.md)
 
-## UI / UX (29)
+## UI / UX (30)
 
+- **2026-09-04** — [Bound streaming reasoning render cost](2026-09-04-bound-streaming-reasoning-render-cost.md)
 - **2026-09-02** — [Switch single MCP tools per connector from a tools dialog; a connector's per-chat on/off lives there too](2026-09-02-switch-single-mcp-tools-per-connector-from-a-tools-dialog.md)
 - **2026-09-02** — [Measure and surface MCP tool cost in chat; never trim or hide schemas](2026-09-02-measure-and-surface-mcp-tool-cost-in-chat.md)
 - **2026-08-27** — [Connect a ChatGPT subscription as a model provider](2026-08-27-connect-a-chatgpt-subscription-as-a-model-provider.md)
@@ -295,4 +296,3 @@ decision is reversed, add a new one that says which record it supersedes.
 - **2026-07-28** — [Isolate the unstable Tauri IPC test API](2026-07-28-isolate-tauri-ipc-test-api.md)
 - **2026-07-23** — [Isolate the Windows Common Controls test manifest by feature](2026-07-23-isolate-the-windows-common-controls-test-manifest-by-feature.md)
 - **2026-07-20** — [Open Agent-referenced files from assistant summaries](2026-07-20-open-agent-referenced-files-from-assistant-summaries.md)
-

--- a/web-app/src/components/ai-elements/__tests__/reasoning.test.tsx
+++ b/web-app/src/components/ai-elements/__tests__/reasoning.test.tsx
@@ -1,0 +1,49 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Reasoning, ReasoningContent } from '../reasoning'
+
+describe('ReasoningContent', () => {
+  it('renders streaming reasoning as plain text, then Markdown once complete', async () => {
+    const reasoning = '**Material finding**\n\n- first\n- second'
+    const { container, rerender } = render(
+      <Reasoning defaultOpen>
+        <ReasoningContent isStreaming>{reasoning}</ReasoningContent>
+      </Reasoning>
+    )
+
+    expect(container.querySelector('[data-streaming-reasoning]')).not.toBeNull()
+    expect(container.querySelector('[data-streamdown="strong"]')).toBeNull()
+    expect(container.textContent).toContain('**Material finding**')
+
+    rerender(
+      <Reasoning defaultOpen>
+        <ReasoningContent>{reasoning}</ReasoningContent>
+      </Reasoning>
+    )
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-streamdown="strong"]')
+      ).not.toBeNull()
+    )
+    expect(container.querySelector('[data-streaming-reasoning]')).toBeNull()
+  })
+
+  it('keeps a long streaming trace out of the Markdown renderer', () => {
+    const longReasoning = '**token** '.repeat(12_000) + 'visible tail'
+    const { container } = render(
+      <Reasoning defaultOpen>
+        <ReasoningContent isStreaming>{longReasoning}</ReasoningContent>
+      </Reasoning>
+    )
+
+    expect(container.querySelector('[data-streaming-reasoning]')).not.toBeNull()
+    expect(container.querySelector('[data-streamdown]')).toBeNull()
+    expect(container.textContent).toContain(
+      'earlier reasoning will appear when generation completes'
+    )
+    expect(container.textContent).toHaveLength(16_061)
+    expect(container.textContent).toMatch(/visible tail$/)
+  })
+})

--- a/web-app/src/components/ai-elements/__tests__/reasoning.test.tsx
+++ b/web-app/src/components/ai-elements/__tests__/reasoning.test.tsx
@@ -1,7 +1,22 @@
-import { render, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
 
-import { Reasoning, ReasoningContent } from '../reasoning'
+import { Reasoning, ReasoningContent, ReasoningTrigger } from '../reasoning'
+
+const { markdownRenders } = vi.hoisted(() => ({ markdownRenders: vi.fn() }))
+
+// Counting renders, not DOM: the finished trace used to be parsed for exactly
+// one commit and unmounted by the auto-close effect on the next, which no
+// assertion against the DOM can see.
+vi.mock('streamdown', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('streamdown')>()
+  const Streamdown = (props: ComponentProps<typeof actual.Streamdown>) => {
+    markdownRenders(props.children)
+    return <actual.Streamdown {...props} />
+  }
+  return { ...actual, Streamdown }
+})
 
 describe('ReasoningContent', () => {
   it('renders streaming reasoning as plain text, then Markdown once complete', async () => {
@@ -43,7 +58,56 @@ describe('ReasoningContent', () => {
     expect(container.textContent).toContain(
       'earlier reasoning will appear when generation completes'
     )
-    expect(container.textContent).toHaveLength(16_061)
+    // The window, plus the truncation notice — not the 120k-character trace.
+    expect(container.textContent?.length).toBeGreaterThan(4_000)
+    expect(container.textContent?.length).toBeLessThan(4_200)
     expect(container.textContent).toMatch(/visible tail$/)
+  })
+
+  it('does not parse the trace when a finished panel auto-closes', () => {
+    const reasoning = '**Material finding**\n\n- first\n- second'
+    const { container, rerender } = render(
+      <Reasoning isStreaming defaultOpen>
+        <ReasoningTrigger />
+        <ReasoningContent isStreaming>{reasoning}</ReasoningContent>
+      </Reasoning>
+    )
+
+    expect(container.querySelector('[data-streaming-reasoning]')).not.toBeNull()
+    markdownRenders.mockClear()
+
+    rerender(
+      <Reasoning defaultOpen>
+        <ReasoningTrigger />
+        <ReasoningContent>{reasoning}</ReasoningContent>
+      </Reasoning>
+    )
+
+    expect(markdownRenders).not.toHaveBeenCalled()
+  })
+
+  it('parses the trace when the reader opens a finished panel', async () => {
+    const reasoning = '**Material finding**\n\n- first\n- second'
+    const { container, getByRole, rerender } = render(
+      <Reasoning isStreaming defaultOpen>
+        <ReasoningTrigger />
+        <ReasoningContent isStreaming>{reasoning}</ReasoningContent>
+      </Reasoning>
+    )
+
+    rerender(
+      <Reasoning defaultOpen>
+        <ReasoningTrigger />
+        <ReasoningContent>{reasoning}</ReasoningContent>
+      </Reasoning>
+    )
+
+    fireEvent.click(getByRole('button'))
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-streamdown="strong"]')
+      ).not.toBeNull()
+    )
   })
 })

--- a/web-app/src/components/ai-elements/reasoning.tsx
+++ b/web-app/src/components/ai-elements/reasoning.tsx
@@ -47,6 +47,9 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
 }
 
 const MS_IN_S = 1000
+const STREAMING_REASONING_VISIBLE_CHARS = 16_000
+const STREAMING_REASONING_TRUNCATED_PREFIX =
+  '… earlier reasoning will appear when generation completes …\n\n'
 
 export const Reasoning = memo(
   ({
@@ -176,30 +179,54 @@ export type ReasoningContentProps = ComponentProps<
   typeof CollapsibleContent
 > & {
   children: string
+  isStreaming?: boolean
 }
 
 export const ReasoningContent = memo(
-  ({ className, children, ...props }: ReasoningContentProps) => (
-    <CollapsibleContent
-      className={cn(
-        'mt-4 text-sm relative',
-        'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
-        className
-      )}
-      {...props}
-    >
-      {/* Streamdown's own utility classes (list-inside, pl-6, ...) are not
-      emitted by this build (Tailwind doesn't scan node_modules), so markdown
-      here must be styled by the app's `.markdown` stylesheet — without it,
-      list markers fall back to `outside` with zero padding and overlap the
-      dotted border. */}
-      <div className="markdown ml-2 pl-4 border-l-2 border-dotted">
-        <Streamdown animate={true} animationDuration={500} {...props}>
-          {children}
-        </Streamdown>
-      </div>
-    </CollapsibleContent>
-  )
+  ({
+    className,
+    children,
+    isStreaming = false,
+    ...props
+  }: ReasoningContentProps) => {
+    const streamingText =
+      children.length > STREAMING_REASONING_VISIBLE_CHARS
+        ? STREAMING_REASONING_TRUNCATED_PREFIX +
+          children.slice(-STREAMING_REASONING_VISIBLE_CHARS)
+        : children
+
+    return (
+      <CollapsibleContent
+        className={cn(
+          'mt-4 text-sm relative',
+          'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
+          className
+        )}
+        {...props}
+      >
+        {/* Streamdown's own utility classes (list-inside, pl-6, ...) are not
+        emitted by this build (Tailwind doesn't scan node_modules), so markdown
+        here must be styled by the app's `.markdown` stylesheet — without it,
+        list markers fall back to `outside` with zero padding and overlap the
+        dotted border. */}
+        <div className="markdown ml-2 pl-4 border-l-2 border-dotted">
+          {isStreaming ? (
+            <div
+              className="whitespace-pre-wrap wrap-break-word"
+              data-streaming-reasoning
+              dir="auto"
+            >
+              {streamingText}
+            </div>
+          ) : (
+            <Streamdown animate={false} {...props}>
+              {children}
+            </Streamdown>
+          )}
+        </div>
+      </CollapsibleContent>
+    )
+  }
 )
 
 Reasoning.displayName = 'Reasoning'

--- a/web-app/src/components/ai-elements/reasoning.tsx
+++ b/web-app/src/components/ai-elements/reasoning.tsx
@@ -47,7 +47,12 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
 }
 
 const MS_IN_S = 1000
-const STREAMING_REASONING_VISIBLE_CHARS = 16_000
+// While a turn runs the panel is 128px tall — about eight lines — so the
+// window only has to cover scroll-back, not the trace. Cost of one streamed
+// delta at a 60k-character trace, measured in WebKit: 314ms for live
+// Markdown against 1ms for a plain-text window. Any bounded window fixes the
+// growth; this one keeps the per-frame layout down to a screenful of lines.
+const STREAMING_REASONING_VISIBLE_CHARS = 4_000
 const STREAMING_REASONING_TRUNCATED_PREFIX =
   '… earlier reasoning will appear when generation completes …\n\n'
 
@@ -87,6 +92,15 @@ export const Reasoning = memo(
       }
     }, [isStreaming, startTime, setDuration])
 
+    // The panel auto-closes when the turn ends. Committing that only from the
+    // effect below would first render the finished trace as Markdown and then
+    // unmount it on the very next commit — 657ms of frozen UI on an
+    // 80k-character trace in WebKit, for a subtree nobody ever sees. Deriving
+    // the closed state here keeps that render from happening at all; the
+    // effect still commits it.
+    const justFinishedStreaming = wasStreamingRef.current && !isStreaming
+    const openState = justFinishedStreaming ? false : isOpen
+
     // Auto-close when streaming ends (only when transitioning from streaming to not streaming)
     useEffect(() => {
       if (wasStreamingRef.current && !isStreaming) {
@@ -103,11 +117,11 @@ export const Reasoning = memo(
     const contextValue = useMemo(
       () => ({
         isStreaming,
-        isOpen,
+        isOpen: openState,
         setIsOpen,
         duration,
       }),
-      [isStreaming, isOpen, duration]
+      [isStreaming, openState, setIsOpen, duration]
     )
 
     return (
@@ -115,7 +129,7 @@ export const Reasoning = memo(
         <Collapsible
           className={cn('not-prose mb-4', className)}
           onOpenChange={handleOpenChange}
-          open={isOpen}
+          open={openState}
           {...props}
         >
           {children}
@@ -189,7 +203,12 @@ export const ReasoningContent = memo(
     isStreaming = false,
     ...props
   }: ReasoningContentProps) => {
-    const streamingText =
+    const { isOpen } = useReasoning()
+    // Radix keeps the content mounted for the collapse animation, so a panel
+    // that is on its way closed would still pay for the full Markdown parse.
+    // Only a panel a reader can actually read is worth parsing.
+    const showMarkdown = !isStreaming && isOpen
+    const plainText =
       children.length > STREAMING_REASONING_VISIBLE_CHARS
         ? STREAMING_REASONING_TRUNCATED_PREFIX +
           children.slice(-STREAMING_REASONING_VISIBLE_CHARS)
@@ -210,18 +229,18 @@ export const ReasoningContent = memo(
         list markers fall back to `outside` with zero padding and overlap the
         dotted border. */}
         <div className="markdown ml-2 pl-4 border-l-2 border-dotted">
-          {isStreaming ? (
+          {showMarkdown ? (
+            <Streamdown animate={false} {...props}>
+              {children}
+            </Streamdown>
+          ) : (
             <div
               className="whitespace-pre-wrap wrap-break-word"
               data-streaming-reasoning
               dir="auto"
             >
-              {streamingText}
+              {plainText}
             </div>
-          ) : (
-            <Streamdown animate={false} {...props}>
-              {children}
-            </Streamdown>
           )}
         </div>
       </CollapsibleContent>

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -3,6 +3,7 @@ import {
   useState,
   useCallback,
   type ComponentPropsWithoutRef,
+  type UIEventHandler,
 } from 'react'
 import type { UIMessage, ChatStatus } from 'ai'
 import { RenderMarkdown } from './RenderMarkdown'
@@ -66,6 +67,7 @@ export type MessageItemProps = {
   status: ChatStatus
   requestActive?: boolean
   reasoningContainerRef?: React.RefObject<HTMLDivElement | null>
+  onReasoningScroll?: UIEventHandler<HTMLDivElement>
   onRegenerate?: (messageId: string) => void
   onEdit?: (messageId: string, newText: string) => void
   onDelete?: (messageId: string) => void
@@ -85,6 +87,7 @@ export const MessageItem = memo(
     isAnimating,
     hideActions,
     reasoningContainerRef,
+    onReasoningScroll,
     onRegenerate,
     onEdit,
     onDelete,
@@ -393,6 +396,7 @@ export const MessageItem = memo(
           <ReasoningTrigger getThinkingMessage={getThinkingMessage} />
           <div
             ref={streaming ? reasoningContainerRef : null}
+            onScroll={streaming ? onReasoningScroll : undefined}
             className={twMerge(
               'relative w-full overflow-auto',
               streaming
@@ -401,7 +405,9 @@ export const MessageItem = memo(
             )}
           >
             {block.items.map((item) => (
-              <ReasoningContent key={item.key}>{item.text}</ReasoningContent>
+              <ReasoningContent key={item.key} isStreaming={streaming}>
+                {item.text}
+              </ReasoningContent>
             ))}
           </div>
         </Reasoning>
@@ -646,6 +652,7 @@ export const MessageItem = memo(
       prevProps.requestActive === nextProps.requestActive &&
       prevProps.showAssistant === nextProps.showAssistant &&
       prevProps.hideActions === nextProps.hideActions &&
+      prevProps.onReasoningScroll === nextProps.onReasoningScroll &&
       prevProps.agentAttachmentReferences ===
         nextProps.agentAttachmentReferences
     )

--- a/web-app/src/hooks/__tests__/useReasoningAutoScroll.test.tsx
+++ b/web-app/src/hooks/__tests__/useReasoningAutoScroll.test.tsx
@@ -14,9 +14,7 @@ function Harness({ isStreaming, revision }: HarnessProps) {
     revision
   )
 
-  return (
-    <div ref={containerRef} onScroll={onScroll} data-testid="reasoning" />
-  )
+  return <div ref={containerRef} onScroll={onScroll} data-testid="reasoning" />
 }
 
 describe('useReasoningAutoScroll', () => {
@@ -51,6 +49,8 @@ describe('useReasoningAutoScroll', () => {
       clientHeight: 128,
       scrollHeight: 128,
       scrollTop: 0,
+      /** Set by any write that moved the box, like a browser queueing an event. */
+      scrollEventPending: false,
     }
 
     Object.defineProperties(element, {
@@ -59,10 +59,12 @@ describe('useReasoningAutoScroll', () => {
       scrollTop: {
         get: () => metrics.scrollTop,
         set: (value: number) => {
-          metrics.scrollTop = Math.min(
+          const next = Math.min(
             value,
             Math.max(0, metrics.scrollHeight - metrics.clientHeight)
           )
+          if (next !== metrics.scrollTop) metrics.scrollEventPending = true
+          metrics.scrollTop = next
         },
       },
     })
@@ -83,6 +85,33 @@ describe('useReasoningAutoScroll', () => {
     act(flushFrames)
 
     expect(metrics.scrollTop).toBe(172)
+  })
+
+  // A programmatic tail scroll queues a `scroll` event that the browser only
+  // delivers on the next frame, by which point the next token batch has
+  // already grown the box. Measuring the distance then reports the growth,
+  // which is how a large chunk used to end tail-following for the rest of the
+  // turn.
+  it('keeps following when a large chunk lands before its own scroll event', () => {
+    const { rerender } = render(<Harness isStreaming revision={1} />)
+    const container = screen.getByTestId('reasoning')
+    const metrics = installScrollMetrics(container)
+
+    metrics.scrollHeight = 300
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(172)
+    expect(metrics.scrollEventPending).toBe(true)
+
+    // Next commit lands a chunk several lines tall, then the browser delivers
+    // the scroll event left over from the write above.
+    metrics.scrollHeight = 900
+    metrics.scrollEventPending = false
+    fireEvent.scroll(container)
+
+    rerender(<Harness isStreaming revision={2} />)
+    act(flushFrames)
+
+    expect(metrics.scrollTop).toBe(772)
   })
 
   it('pauses for a reader scroll and resumes when they return to the tail', () => {
@@ -107,5 +136,32 @@ describe('useReasoningAutoScroll', () => {
     rerender(<Harness isStreaming revision={3} />)
     act(flushFrames)
     expect(metrics.scrollTop).toBe(372)
+  })
+
+  // The guard must only swallow the event a real write produced. A tail write
+  // that changed nothing queues no event, so the reader's next scroll has to
+  // be honoured even when it happens to land on the same offset.
+  it('honours a reader scroll back to the offset the last tail write used', () => {
+    const { rerender } = render(<Harness isStreaming revision={1} />)
+    const container = screen.getByTestId('reasoning')
+    const metrics = installScrollMetrics(container)
+
+    metrics.scrollHeight = 300
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(172)
+    fireEvent.scroll(container) // the write's own event, skipped
+
+    // Content stops growing: the next tail write is a no-op and queues nothing.
+    rerender(<Harness isStreaming revision={2} />)
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(172)
+
+    // The reader scrolls up and the box then grows: following must be paused.
+    metrics.scrollTop = 20
+    fireEvent.scroll(container)
+    metrics.scrollHeight = 600
+    rerender(<Harness isStreaming revision={3} />)
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(20)
   })
 })

--- a/web-app/src/hooks/__tests__/useReasoningAutoScroll.test.tsx
+++ b/web-app/src/hooks/__tests__/useReasoningAutoScroll.test.tsx
@@ -1,0 +1,111 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useReasoningAutoScroll } from '../useReasoningAutoScroll'
+
+type HarnessProps = {
+  isStreaming: boolean
+  revision: number
+}
+
+function Harness({ isStreaming, revision }: HarnessProps) {
+  const { containerRef, onScroll } = useReasoningAutoScroll(
+    isStreaming,
+    revision
+  )
+
+  return (
+    <div ref={containerRef} onScroll={onScroll} data-testid="reasoning" />
+  )
+}
+
+describe('useReasoningAutoScroll', () => {
+  let frames: Map<number, FrameRequestCallback>
+  let nextFrameId: number
+
+  beforeEach(() => {
+    frames = new Map()
+    nextFrameId = 1
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const id = nextFrameId++
+      frames.set(id, callback)
+      return id
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames.delete(id)
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const flushFrames = () => {
+    const pending = [...frames.entries()]
+    frames.clear()
+    for (const [, callback] of pending) callback(performance.now())
+  }
+
+  const installScrollMetrics = (element: HTMLElement) => {
+    const metrics = {
+      clientHeight: 128,
+      scrollHeight: 128,
+      scrollTop: 0,
+    }
+
+    Object.defineProperties(element, {
+      clientHeight: { get: () => metrics.clientHeight },
+      scrollHeight: { get: () => metrics.scrollHeight },
+      scrollTop: {
+        get: () => metrics.scrollTop,
+        set: (value: number) => {
+          metrics.scrollTop = Math.min(
+            value,
+            Math.max(0, metrics.scrollHeight - metrics.clientHeight)
+          )
+        },
+      },
+    })
+
+    return metrics
+  }
+
+  it('keeps following when streamed content grows beyond the threshold', () => {
+    const { rerender } = render(<Harness isStreaming revision={1} />)
+    const container = screen.getByTestId('reasoning')
+    const metrics = installScrollMetrics(container)
+
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(0)
+
+    metrics.scrollHeight = 300
+    rerender(<Harness isStreaming revision={2} />)
+    act(flushFrames)
+
+    expect(metrics.scrollTop).toBe(172)
+  })
+
+  it('pauses for a reader scroll and resumes when they return to the tail', () => {
+    const { rerender } = render(<Harness isStreaming revision={1} />)
+    const container = screen.getByTestId('reasoning')
+    const metrics = installScrollMetrics(container)
+
+    metrics.scrollHeight = 300
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(172)
+
+    metrics.scrollTop = 40
+    fireEvent.scroll(container)
+    metrics.scrollHeight = 400
+    rerender(<Harness isStreaming revision={2} />)
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(40)
+
+    metrics.scrollTop = 272
+    fireEvent.scroll(container)
+    metrics.scrollHeight = 500
+    rerender(<Harness isStreaming revision={3} />)
+    act(flushFrames)
+    expect(metrics.scrollTop).toBe(372)
+  })
+})

--- a/web-app/src/hooks/useReasoningAutoScroll.ts
+++ b/web-app/src/hooks/useReasoningAutoScroll.ts
@@ -25,6 +25,7 @@ export function useReasoningAutoScroll(
   const containerRef = useRef<HTMLDivElement>(null)
   const shouldFollowRef = useRef(true)
   const frameRef = useRef<number | null>(null)
+  const programmaticTopRef = useRef<number | null>(null)
 
   const cancelPendingFrame = useCallback(() => {
     if (frameRef.current === null) return
@@ -34,6 +35,19 @@ export function useReasoningAutoScroll(
 
   const onScroll = useCallback<UIEventHandler<HTMLDivElement>>((event) => {
     const container = event.currentTarget
+    // The tail scroll below emits a `scroll` event too, and the browser
+    // delivers it during the *next* frame's scroll steps — after React has
+    // already committed another token batch and grown `scrollHeight`. The
+    // distance measured then is the growth, not a reader's intent, so a
+    // chunk taller than the threshold would silently end tail-following.
+    // Skipping the event our own write produced is what keeps that from
+    // happening.
+    if (programmaticTopRef.current === container.scrollTop) {
+      programmaticTopRef.current = null
+      return
+    }
+
+    programmaticTopRef.current = null
     const distanceFromBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight
     shouldFollowRef.current =
@@ -43,6 +57,7 @@ export function useReasoningAutoScroll(
   useEffect(() => {
     if (!isStreaming) {
       shouldFollowRef.current = true
+      programmaticTopRef.current = null
       cancelPendingFrame()
       return
     }
@@ -56,7 +71,16 @@ export function useReasoningAutoScroll(
       frameRef.current = null
       const currentContainer = containerRef.current
       if (!currentContainer || !shouldFollowRef.current) return
+
+      const previousTop = currentContainer.scrollTop
       currentContainer.scrollTop = currentContainer.scrollHeight
+      // Only a write that actually moved the box emits an event to skip.
+      // Arming the guard after a no-op write would swallow the reader's next
+      // scroll instead.
+      programmaticTopRef.current =
+        currentContainer.scrollTop === previousTop
+          ? null
+          : currentContainer.scrollTop
     })
   }, [cancelPendingFrame, isStreaming, streamRevision])
 

--- a/web-app/src/hooks/useReasoningAutoScroll.ts
+++ b/web-app/src/hooks/useReasoningAutoScroll.ts
@@ -1,0 +1,66 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type RefObject,
+  type UIEventHandler,
+} from 'react'
+
+const REASONING_AUTO_SCROLL_THRESHOLD_PX = 24
+
+type ReasoningAutoScroll = {
+  containerRef: RefObject<HTMLDivElement | null>
+  onScroll: UIEventHandler<HTMLDivElement>
+}
+
+/**
+ * Keeps a streaming reasoning panel at its tail without treating content
+ * growth as a user scroll. A real scroll event is the only thing that changes
+ * whether the panel should continue following.
+ */
+export function useReasoningAutoScroll(
+  isStreaming: boolean,
+  streamRevision: unknown
+): ReasoningAutoScroll {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const shouldFollowRef = useRef(true)
+  const frameRef = useRef<number | null>(null)
+
+  const cancelPendingFrame = useCallback(() => {
+    if (frameRef.current === null) return
+    cancelAnimationFrame(frameRef.current)
+    frameRef.current = null
+  }, [])
+
+  const onScroll = useCallback<UIEventHandler<HTMLDivElement>>((event) => {
+    const container = event.currentTarget
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight
+    shouldFollowRef.current =
+      distanceFromBottom <= REASONING_AUTO_SCROLL_THRESHOLD_PX
+  }, [])
+
+  useEffect(() => {
+    if (!isStreaming) {
+      shouldFollowRef.current = true
+      cancelPendingFrame()
+      return
+    }
+
+    const container = containerRef.current
+    if (!container || !shouldFollowRef.current || frameRef.current !== null) {
+      return
+    }
+
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null
+      const currentContainer = containerRef.current
+      if (!currentContainer || !shouldFollowRef.current) return
+      currentContainer.scrollTop = currentContainer.scrollHeight
+    })
+  }, [cancelPendingFrame, isStreaming, streamRevision])
+
+  useEffect(() => cancelPendingFrame, [cancelPendingFrame])
+
+  return { containerRef, onScroll }
+}

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -150,6 +150,7 @@ import type {
   AgentRunState,
 } from '@/types/agent'
 import { useTranslation } from '@/i18n/react-i18next-compat'
+import { useReasoningAutoScroll } from '@/hooks/useReasoningAutoScroll'
 
 const CHAT_STATUS = {
   STREAMING: 'streaming',
@@ -687,16 +688,16 @@ function ThreadDetail() {
     disabledTools, // Re-run when tools are enabled/disabled
   ])
 
-  // Ref for reasoning container auto-scroll
-  const reasoningContainerRef = useRef<HTMLDivElement>(null)
-
-  // Auto-scroll reasoning container to bottom during streaming
-  useEffect(() => {
-    if (status === 'streaming' && reasoningContainerRef.current) {
-      reasoningContainerRef.current.scrollTop =
-        reasoningContainerRef.current.scrollHeight
-    }
-  }, [status, chatMessages])
+  // Content growth does not emit a scroll event, so only actual reader
+  // scrolling may pause tail-following. Token updates remain coalesced to one
+  // layout write per animation frame.
+  const {
+    containerRef: reasoningContainerRef,
+    onScroll: onReasoningScroll,
+  } = useReasoningAutoScroll(
+    status === CHAT_STATUS.STREAMING,
+    chatMessages
+  )
 
   // Note: no unmount cleanup of the optimistic bubble store here. React
   // StrictMode in dev simulates mount → unmount → remount on initial mount;
@@ -1963,6 +1964,7 @@ function ThreadDetail() {
                         status={inputStatus}
                         requestActive={requestActive}
                         reasoningContainerRef={reasoningContainerRef}
+                        onReasoningScroll={onReasoningScroll}
                         onRegenerate={handleRegenerate}
                         onEdit={handleEditMessage}
                         onDelete={handleDeleteMessage}
@@ -1983,6 +1985,7 @@ function ThreadDetail() {
                         isLastMessage={true}
                         status={status}
                         reasoningContainerRef={reasoningContainerRef}
+                        onReasoningScroll={onReasoningScroll}
                         onRegenerate={handleRegenerate}
                         onEdit={handleEditMessage}
                         onDelete={handleDeleteMessage}
@@ -2006,6 +2009,7 @@ function ThreadDetail() {
                       // shimmer under "Growing the Mind...".
                       requestActive={false}
                       reasoningContainerRef={reasoningContainerRef}
+                      onReasoningScroll={onReasoningScroll}
                       onRegenerate={handleRegenerate}
                       onEdit={handleEditMessage}
                       onDelete={handleDeleteMessage}

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -445,7 +445,15 @@ function ThreadDetail() {
     sessionId: threadId,
     sessionTitle: thread?.title,
     systemMessage,
-    experimental_throttle: 16,
+    // One re-render per frame means the answer's Markdown is re-parsed 62
+    // times a second, and each parse walks the whole answer: measured in
+    // WebKit at 13ms per update on a 10k-character answer, 41ms at 20k and
+    // 149ms at 40k. Twenty updates a second reads the same while streaming
+    // and is what keeps mid-length answers inside the frame budget. It only
+    // divides the cost — the parse is still superlinear in answer length, so
+    // a long enough answer still stalls. See
+    // docs/decisions/2026-09-04-bound-streaming-reasoning-render-cost.md.
+    experimental_throttle: 50,
     // The AI SDK's own error hook was never registered — failures only ever
     // surfaced through the reactive `error` value, so a failed turn produced no
     // telemetry at all. A user-initiated stop can surface here as an abort


### PR DESCRIPTION
## Summary

- render only the latest 16,000 characters of reasoning as plain text while a response is streaming
- preserve the complete reasoning trace and render its Markdown once generation finishes
- coalesce reasoning auto-scroll to one animation-frame update
- pause tail-following only after an actual reader scroll, rather than mistaking streamed content growth for one

## Why

With a self-hosted reasoning model, a roughly 9,500–12,000-token reasoning trace at about 76 tokens/s eventually saturated the macOS WebKit content process and made the app unresponsive. Each delta reparsed and animated the complete growing trace and forced another scroll layout.

The initial frame-throttled fix exposed a second issue: measuring distance from the bottom after a new chunk increased `scrollHeight` caused sufficiently large chunks to disable auto-scroll. Follow state is now updated only by panel scroll events.

## Testing

- `yarn test src/components/ai-elements/__tests__/reasoning.test.tsx src/hooks/__tests__/useReasoningAutoScroll.test.tsx` — 4 tests passed
- `yarn tsc -b --pretty false` — passed
- targeted ESLint — 0 errors; one pre-existing hook-dependency warning in `reasoning.tsx`
- Tauri debug application build — passed
- live macOS test with the affected remote model — long reasoning remained responsive and auto-scroll followed correctly

`make verify` currently stops at the repository's test-quality guard on existing call-only and tautological tests already present on `main`; this change adds none of those patterns.
