### PR TITLE
fix: make complex connectors compatible with llama.cpp grammar

### DIFF
--- a/docs/decisions/2026-09-04-project-mcp-schemas-for-llama-grammar.md
+++ b/docs/decisions/2026-09-04-project-mcp-schemas-for-llama-grammar.md
@@ -1,0 +1,34 @@
+---
+date: 2026-09-04
+title: 'Project MCP schemas before llama.cpp grammar compilation'
+---
+
+# 2026-09-04 — Project MCP schemas before llama.cpp grammar compilation
+
+- **Context:** normal chat sends every enabled MCP tool schema to the selected
+  provider. llama.cpp turns those schemas into constrained GBNF. Firecrawl's 25
+  tools produced a 168 KB, 596-rule grammar containing repetitions such as
+  `char{0,10000}` and arrays up to 100 items; both shipped llama.cpp providers
+  rejected it before generation with `Failed to initialize samplers` because it
+  could not parse the grammar. Increasing context cannot fix a grammar compiler
+  limit.
+- **Decision:** for `llamacpp` and `llamacpp-upstream` chat requests only,
+  recursively omit JSON Schema validation keywords that expand into bounded or
+  regex grammar rules: string, array, object and `contains` cardinality bounds,
+  plus `pattern`, `patternProperties`, and `format`. Preserve tool names,
+  descriptions, property structure, types, required fields, enums and the
+  original MCP catalog. Cloud and MLX providers continue receiving the full
+  schema. Include provider identity in the tool-cache key so switching providers
+  rebuilds the correct projection.
+- **Consequences:** complex connectors can initialize llama.cpp grammars without
+  silently dropping tools. A local model can emit an argument outside a removed
+  constraint; the MCP server still validates the original contract and returns
+  its normal tool error. Tool-cost reporting follows the projected schema. Raw
+  tool count and context cost remain governed by per-chat connector scoping.
+- **Owner:** @xDenside
+- **Links:** `web-app/src/lib/custom-chat-transport-helpers.ts`,
+  `web-app/src/lib/custom-chat-transport.ts`,
+  `docs/decisions/2026-09-02-measure-and-surface-mcp-tool-cost-in-chat.md`
+
+Supersedes: 2026-09-02-measure-and-surface-mcp-tool-cost-in-chat.md (local
+llama.cpp schema validation constraints only)

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -9,7 +9,7 @@ decision is reversed, add a new one that says which record it supersedes.
 2. Add one line to the right section of this index.
 3. Do **not** paste the record body into `AGENTS.md`.
 
-231 records, 2026-05-19 → 2026-09-02.
+233 records, 2026-05-19 → 2026-09-04.
 
 ---
 
@@ -248,8 +248,9 @@ decision is reversed, add a new one that says which record it supersedes.
 - **2026-05-22** — [Pin static WiX `upgradeCode` to legacy Jan UUID for in-place MSI upgrades](2026-05-22-pin-static-wix-upgradecode-to-legacy-jan-uuid-for-in-place-msi.md)
 - **2026-05-19** — [Product identity is "Atomic Chat"; new code stops carrying Jan branding](2026-05-19-product-identity-is-atomic-chat-new-code-stops-carrying-jan.md)
 
-## UI / UX (30)
+## UI / UX (31)
 
+- **2026-09-04** — [Project MCP schemas before llama.cpp grammar compilation](2026-09-04-project-mcp-schemas-for-llama-grammar.md)
 - **2026-09-04** — [Bound streaming reasoning render cost](2026-09-04-bound-streaming-reasoning-render-cost.md)
 - **2026-09-02** — [Switch single MCP tools per connector from a tools dialog; a connector's per-chat on/off lives there too](2026-09-02-switch-single-mcp-tools-per-connector-from-a-tools-dialog.md)
 - **2026-09-02** — [Measure and surface MCP tool cost in chat; never trim or hide schemas](2026-09-02-measure-and-surface-mcp-tool-cost-in-chat.md)

--- a/web-app/src/lib/__tests__/custom-chat-transport-helpers.test.ts
+++ b/web-app/src/lib/__tests__/custom-chat-transport-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildToolsRecord,
+  makeLlamaGrammarSafeSchema,
   splitAnthropicSerialToolUse,
 } from '../custom-chat-transport-helpers'
 import type { MCPTool } from '@/types/completion'
@@ -122,5 +123,62 @@ describe('buildToolsRecord', () => {
     )
 
     expect(result.lookup.description).toBe('RAG version')
+  })
+})
+
+describe('makeLlamaGrammarSafeSchema', () => {
+  it('removes bounded grammar expansions without mutating tool structure', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        maxLength: { type: 'number', maximum: 10_000 },
+        query: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 10_000,
+          pattern: '^[a-z]+$',
+          format: 'hostname',
+        },
+        sources: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 100,
+          items: {
+            type: 'object',
+            properties: {
+              pattern: { type: 'string', maxLength: 2_000 },
+            },
+          },
+        },
+      },
+      patternProperties: {
+        '^x-': { type: 'string', maxLength: 10_000 },
+      },
+      required: ['query'],
+      examples: [{ maxLength: 50, query: 'docs' }],
+    }
+
+    const safe = makeLlamaGrammarSafeSchema(schema)
+    const properties = safe.properties as Record<
+      string,
+      Record<string, unknown>
+    >
+    const sources = properties.sources
+    const itemProperties = (sources.items as Record<string, unknown>)
+      .properties as Record<string, Record<string, unknown>>
+
+    expect(properties.maxLength).toEqual({
+      type: 'number',
+      maximum: 10_000,
+    })
+    expect(properties.query).toEqual({ type: 'string' })
+    expect(sources).not.toHaveProperty('minItems')
+    expect(sources).not.toHaveProperty('maxItems')
+    expect(itemProperties.pattern).toEqual({ type: 'string' })
+    expect(safe).not.toHaveProperty('patternProperties')
+    expect(safe.examples).toEqual([{ maxLength: 50, query: 'docs' }])
+    expect((schema.properties.query as Record<string, unknown>).maxLength).toBe(
+      10_000
+    )
   })
 })

--- a/web-app/src/lib/__tests__/custom-chat-transport.harness.test.ts
+++ b/web-app/src/lib/__tests__/custom-chat-transport.harness.test.ts
@@ -474,6 +474,61 @@ describe('CustomChatTransport per-turn state', () => {
     expect(transport.getTools()).toEqual({})
   })
 
+  it('uses grammar-safe MCP schemas only for llama.cpp providers', async () => {
+    const inputSchema = {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string', maxLength: 10_000 },
+      },
+    }
+    useAppState.setState({
+      tools: [
+        {
+          name: 'firecrawl_search',
+          server: 'firecrawl',
+          description: 'Search the web',
+          inputSchema,
+        },
+      ],
+      mcpToolNames: new Set(['firecrawl_search']),
+    })
+    useModelProvider.setState((state) => ({
+      selectedProvider: 'llamacpp-upstream',
+      selectedModel: {
+        ...state.selectedModel!,
+        capabilities: ['tools'],
+      },
+    }))
+    const transport = new CustomChatTransport(undefined, 'thread-7')
+
+    await transport.updateRagToolsAvailability(false, true, false)
+
+    const localSchema = (
+      transport.getTools().firecrawl_search.inputSchema as {
+        jsonSchema: Record<string, unknown>
+      }
+    ).jsonSchema
+    expect(
+      (localSchema.properties as Record<string, Record<string, unknown>>).prompt
+    ).not.toHaveProperty('maxLength')
+
+    useModelProvider.setState({ selectedProvider: 'openai' })
+    await transport.updateRagToolsAvailability(false, true, false)
+
+    const cloudSchema = (
+      transport.getTools().firecrawl_search.inputSchema as {
+        jsonSchema: Record<string, unknown>
+      }
+    ).jsonSchema
+    expect(
+      (cloudSchema.properties as Record<string, Record<string, unknown>>).prompt
+        .maxLength
+    ).toBe(10_000)
+    expect(
+      (inputSchema.properties.prompt as Record<string, unknown>).maxLength
+    ).toBe(10_000)
+  })
+
   it('prefills the next request with the content to continue from', async () => {
     useGeneralSetting.setState({
       disableReasoning: false,

--- a/web-app/src/lib/custom-chat-transport-helpers.ts
+++ b/web-app/src/lib/custom-chat-transport-helpers.ts
@@ -3,6 +3,91 @@ import { jsonSchema, type Tool } from 'ai'
 
 import type { MCPTool } from '@/types/completion'
 
+const LLAMA_GRAMMAR_EXPANSION_KEYS = new Set([
+  'format',
+  'maxContains',
+  'maxItems',
+  'maxLength',
+  'maxProperties',
+  'minContains',
+  'minItems',
+  'minLength',
+  'minProperties',
+  'pattern',
+  'patternProperties',
+])
+
+const SCHEMA_MAP_KEYS = new Set([
+  '$defs',
+  'definitions',
+  'dependentSchemas',
+  'properties',
+])
+
+const SCHEMA_ARRAY_KEYS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems'])
+
+const SCHEMA_VALUE_KEYS = new Set([
+  'additionalProperties',
+  'contains',
+  'contentSchema',
+  'else',
+  'if',
+  'items',
+  'not',
+  'propertyNames',
+  'then',
+  'unevaluatedItems',
+  'unevaluatedProperties',
+])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Remove only the JSON Schema constraints that llama.cpp expands into large
+ * bounded GBNF repetitions. The MCP server remains the authority for those
+ * limits when it validates the eventual tool call.
+ */
+export function makeLlamaGrammarSafeSchema(
+  schema: Record<string, unknown>
+): Record<string, unknown> {
+  const visitSchema = (value: unknown): unknown => {
+    if (!isRecord(value)) return value
+
+    const result: Record<string, unknown> = {}
+    for (const [key, child] of Object.entries(value)) {
+      if (LLAMA_GRAMMAR_EXPANSION_KEYS.has(key)) continue
+
+      if (SCHEMA_MAP_KEYS.has(key) && isRecord(child)) {
+        result[key] = Object.fromEntries(
+          Object.entries(child).map(([name, nested]) => [
+            name,
+            visitSchema(nested),
+          ])
+        )
+      } else if (SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+        result[key] = child.map(visitSchema)
+      } else if (SCHEMA_VALUE_KEYS.has(key)) {
+        result[key] = Array.isArray(child)
+          ? child.map(visitSchema)
+          : visitSchema(child)
+      } else if (key === 'dependencies' && isRecord(child)) {
+        result[key] = Object.fromEntries(
+          Object.entries(child).map(([name, nested]) => [
+            name,
+            Array.isArray(nested) ? nested : visitSchema(nested),
+          ])
+        )
+      } else {
+        result[key] = child
+      }
+    }
+    return result
+  }
+
+  return visitSchema(schema) as Record<string, unknown>
+}
+
 export function splitAnthropicSerialToolUse(
   messages: UIMessage[]
 ): UIMessage[] {
@@ -43,7 +128,8 @@ export function splitAnthropicSerialToolUse(
 export function buildToolsRecord(
   ragTools: readonly MCPTool[],
   mcpTools: readonly MCPTool[],
-  disabledToolKeys: readonly string[]
+  disabledToolKeys: readonly string[],
+  options: { llamaGrammarSafe?: boolean } = {}
 ): Record<string, Tool> {
   const disabled = new Set(disabledToolKeys)
   const toolsRecord: Record<string, Tool> = {}
@@ -52,9 +138,12 @@ export function buildToolsRecord(
     const serverName = tool.server || 'unknown'
     if (disabled.has(`${serverName}::${tool.name}`)) continue
 
+    const inputSchema = options.llamaGrammarSafe
+      ? makeLlamaGrammarSafeSchema(tool.inputSchema)
+      : tool.inputSchema
     toolsRecord[tool.name] = {
       description: tool.description,
-      inputSchema: jsonSchema(tool.inputSchema),
+      inputSchema: jsonSchema(inputSchema),
     } as Tool
   }
 

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -16,6 +16,7 @@ import { repairToolCallArguments } from './repairToolCall'
 import { prepareToolResultImagesForModel } from './toolResultImages'
 import {
   buildToolsRecord,
+  makeLlamaGrammarSafeSchema,
   splitAnthropicSerialToolUse,
 } from './custom-chat-transport-helpers'
 import type { MCPTool } from '@/types/completion'
@@ -429,7 +430,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     disabledToolKeys: string[],
     hasDocuments: boolean,
     ragFeatureAvailable: boolean,
-    modelSupportsTools: boolean
+    modelSupportsTools: boolean,
+    providerId: string
   ): string {
     const mcp = [...useAppState.getState().mcpToolNames].sort().join(',')
     const rag = [...useAppState.getState().ragToolNames].sort().join(',')
@@ -439,6 +441,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     const ctxLen = readModelCtxLen(useModelProvider.getState().selectedModel)
     return [
       this.threadId ?? '',
+      providerId,
       hasDocuments,
       ragFeatureAvailable,
       modelSupportsTools,
@@ -471,7 +474,11 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       ? getDisabledToolsForThread(this.threadId)
       : useToolAvailable.getState().getDefaultDisabledTools()
 
-    const selectedModel = useModelProvider.getState().selectedModel
+    const providerState = useModelProvider.getState()
+    const selectedModel = providerState.selectedModel
+    const providerId = providerState.selectedProvider
+    const llamaGrammarSafe =
+      providerId === 'llamacpp' || providerId === 'llamacpp-upstream'
     const modelSupportsTools =
       selectedModel?.capabilities?.includes('tools') ?? this.modelSupportsTools
 
@@ -490,7 +497,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       disabledToolKeys,
       hasDocuments,
       ragFeatureAvailable,
-      modelSupportsTools
+      modelSupportsTools,
+      providerId
     )
     if (!force && this.toolsCacheValid && cacheKey === this.toolsCacheKey) {
       return
@@ -562,7 +570,9 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     ])
     const audibleMcpTools = mcpTools.filter((tool) => !muted.has(tool.server))
 
-    this.tools = buildToolsRecord(ragTools, audibleMcpTools, disabledToolKeys)
+    this.tools = buildToolsRecord(ragTools, audibleMcpTools, disabledToolKeys, {
+      llamaGrammarSafe,
+    })
     this.toolsCacheKey = cacheKey
     this.toolsCacheValid = true
 
@@ -573,12 +583,18 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     const sentTools = audibleMcpTools.filter(
       (tool) => !disabled.has(`${tool.server || 'unknown'}::${tool.name}`)
     )
+    const measuredTools = llamaGrammarSafe
+      ? sentTools.map((tool) => ({
+          ...tool,
+          inputSchema: makeLlamaGrammarSafeSchema(tool.inputSchema),
+        }))
+      : sentTools
     useAppState
       .getState()
       .setToolCostReport(
         this.threadId ?? '',
         summarizeToolCost(
-          modelSupportsTools ? sentTools : [],
+          modelSupportsTools ? measuredTools : [],
           readModelCtxLen(selectedModel)
         )
       )


### PR DESCRIPTION
## Summary

- project MCP tool schemas into a grammar-safe form for `llamacpp` and `llamacpp-upstream` chat requests
- remove only validation keywords that expand into large bounded or regex GBNF rules; preserve tool names, descriptions, properties, types, required fields, and enums
- retain the original MCP schema in app state so the MCP server remains the final argument validator
- keep cloud and MLX schemas unchanged
- include provider identity in the tool cache and measure tool cost from the schema actually sent

## Why

Firecrawl connects successfully, but its 25 tools expand into a 168 KB, 596-rule grammar containing bounds such as `char{0,10000}` and arrays up to 100 items. The shipped llama.cpp parser rejects the grammar before generation when repeated-rule complexity reaches its safety threshold, producing `Failed to initialize samplers: failed to parse grammar`. The same class of failure appears with other large connector catalogs and under both llama.cpp providers.

This projection avoids the grammar compiler limit without silently dropping tools. A model can produce an argument outside a removed validation constraint, but the MCP server still validates its original contract and returns the normal tool error.

## Verification

- focused helper and transport tests: 29 passed
- web TypeScript build: passed
- affected source and test lint: passed
- full web lint: passed with 13 existing warnings
- full web suite: 2,605 passed, 11 skipped; one unrelated existing provider-picker assertion remains failing (`DropdownModelProvider.connected.test.tsx`)

## Upstream guard

The b10431 llama.cpp backend uses `MAX_REPETITION_THRESHOLD = 2000` and rejects a bounded repetition when `previous_rule_complexity * repetition_count` reaches that limit: https://github.com/ggml-org/llama.cpp/blob/b10431/src/llama-grammar.cpp#L485-L496
